### PR TITLE
Riemann Theta bug fix

### DIFF
--- a/abelfunctions/riemanntheta/Cython-Riemann.pyx
+++ b/abelfunctions/riemanntheta/Cython-Riemann.pyx
@@ -26,6 +26,7 @@ def finite_sum(X, Yinv, T, x, y, S, g):
     cdef double imag[0]
     X = np.ascontiguousarray(X, dtype = 'double')
     Yinv = np.ascontiguousarray(Yinv, dtype = 'double')
+    T = np.ascontiguousarray(T, dtype = 'double')
     x = np.ascontiguousarray(x, dtype = 'double')
     y = np.ascontiguousarray(y, dtype = 'double')
     S = np.ascontiguousarray(S, dtype = 'double')
@@ -49,6 +50,7 @@ def finite_sum_derivatives(X, Yinv, T, x, y, S, deriv, g):
     deriv_imag = np.ascontiguousarray(deriv.imag, dtype = 'double')
     X = np.ascontiguousarray(X, dtype = 'double')
     Yinv = np.ascontiguousarray(Yinv, dtype = 'double')
+    T = np.ascontiguousarray(T, dtype = 'double')
     x = np.ascontiguousarray(x, dtype = 'double')
     y = np.ascontiguousarray(y, dtype = 'double')
     S = np.ascontiguousarray(S, dtype = 'double')


### PR DESCRIPTION
The T matrix was not being made into a contiguous array in
the Cython-Riemann.pyx program, changing T into a contiguous array
fixes the bug.
