### PR TITLE
Use algebraic e-th roots of unity

### DIFF
--- a/abelfunctions/puiseux.py
+++ b/abelfunctions/puiseux.py
@@ -787,7 +787,7 @@ class PuiseuxTSeries(object):
         mu = phi.roots(QQbar, multiplicities=False)[0]
 
         if all_conjugates:
-            zeta_e=QQbar.zeta(eabs)
+            zeta_e=QQbar.zeta(abse)
             conjugates = [mu*zeta_e^k for k in range(abse)]
         else:
             conjugates = [mu]
@@ -799,7 +799,7 @@ class PuiseuxTSeries(object):
             t = self.ypart.parent().gen()
             fconj = self.ypart(c*t)
             p = P(fconj(x**(QQ(1)/e)))
-            p = p.add_bigoh(QQ(order+1)/abs(e))
+            p = p.add_bigoh(QQ(order+1)/abse)
             xseries.append(p)
         return xseries
 

--- a/abelfunctions/puiseux.py
+++ b/abelfunctions/puiseux.py
@@ -788,7 +788,7 @@ class PuiseuxTSeries(object):
 
         if all_conjugates:
             zeta_e=QQbar.zeta(abse)
-            conjugates = [mu*zeta_e^k for k in range(abse)]
+            conjugates = [mu*zeta_e**k for k in range(abse)]
         else:
             conjugates = [mu]
         map(lambda x: x.exactify(), conjugates)

--- a/abelfunctions/puiseux.py
+++ b/abelfunctions/puiseux.py
@@ -42,7 +42,7 @@ import sympy
 
 from abelfunctions.puiseux_series_ring import PuiseuxSeriesRing
 
-from sage.all import I, pi, gcd, xgcd
+from sage.all import gcd, xgcd
 from sage.functions.log import log, exp
 from sage.functions.other import ceil
 from sage.rings.big_oh import O
@@ -775,17 +775,20 @@ class PuiseuxTSeries(object):
 
         # given x = alpha + lambda*t^e solve for t. this involves finding an
         # e-th root of either (1/lambda) or of lambda, depending on e's sign
+        ## (A sign on a ramification index ? hm)
         e = self.ramification_index
+        abse = abs(e)
         lamb = S(self.xcoefficient)
         order = self.order
         if e > 0:
             phi = lamb*z**e - 1
         else:
-            phi = z**abs(e) - lamb
+            phi = z**abse - lamb
         mu = phi.roots(QQbar, multiplicities=False)[0]
 
         if all_conjugates:
-            conjugates = [mu*exp(2*pi*I*k/abs(e)) for k in range(abs(e))]
+            zeta_e=QQbar.zeta(eabs)
+            conjugates = [mu*zeta_e^k for k in range(abse)]
         else:
             conjugates = [mu]
         map(lambda x: x.exactify(), conjugates)


### PR DESCRIPTION
remove import of symbolic I and pi and replace their use by constructions that construct e-th roots of unity in QQbar directly

---
I'm surprised this code ever worked. Indeed sage can recognize these symbolic expressions as algebraic:
 
```
     sage: QQbar(exp(2*pi/17*I))
     0.9324722294043558? + 0.3612416661871530?*I

```
It seems that on one version of sage this led to "exactify" working on a symbolic expression, but that seems to be no longer the case. It's better to leave the symbolic ring out of it completely.