### PR TITLE
Generalize Riemann theta for N derivatives

### DIFF
--- a/abelfunctions/riemann_theta/finite_sum.c
+++ b/abelfunctions/riemann_theta/finite_sum.c
@@ -127,18 +127,18 @@ normpart(double* n, double* T, double* fracshift, int g)
 
   Parameters
   ----------
-  * X, Yinv, T : double[:]
-        Row-major matrices such that the Riemann matrix, Omega is equal to (X +
-        iY). T is the Cholesky decomposition of Y.
-  * x, y : double[:]
-        The real and imaginary parts of the input vector, z.
-  * S : double[:]
-        The set of points in ZZ^g over which to compute the finite sum
-  * g : int
-        The dimension of the above matrices and vectors
-  * N : int
-       The number of points in ZZ^g over which to compute the sum
-       (= total number of elements in S / g)
+  X, Yinv, T : double[:]
+      Row-major matrices such that the Riemann matrix, Omega is equal to (X +
+      iY). T is the Cholesky decomposition of Y.
+  x, y : double[:]
+      The real and imaginary parts of the input vector, z.
+  S : double[:]
+      The set of points in ZZ^g over which to compute the finite sum
+  g : int
+      The dimension of the above matrices and vectors
+  N : int
+     The number of points in ZZ^g over which to compute the sum
+     (= total number of elements in S / g)
 
   Returns
   -------
@@ -205,8 +205,8 @@ finite_sum_without_derivatives(double* fsum_real, double* fsum_imag,
   ----------
 
   Compute the real and imaginary parts of the product
-                   ___
-                   | |    2*pi*I <d, n-intshift>
+             ___
+             | |    2*pi*I <d, n-intshift>
 	           | |
 	       d in derivs
 
@@ -214,16 +214,16 @@ finite_sum_without_derivatives(double* fsum_real, double* fsum_imag,
 
   Parameters
   ----------
-  * n : double[:]
-        An integer vector in the finite sum ellipsoid.
-  * intshift : double[:]
-        The integer part of Yinv*y.
-  * deriv_real, deriv_imag : double[:]
-        The real and imaginary parts of the derivative directional vectors.
-  * nderivs : int
-        Number / order of derivatives.
-  * g : int
-        Genus / dimension of the problem.
+  n : double[:]
+      An integer vector in the finite sum ellipsoid.
+  intshift : double[:]
+      The integer part of Yinv*y.
+  deriv_real, deriv_imag : double[:]
+      The real and imaginary parts of the derivative directional vectors.
+  nderivs : int
+      Number / order of derivatives.
+  g : int
+      Genus / dimension of the problem.
 
   Returns
   -------
@@ -305,27 +305,27 @@ deriv_prod(double* dpr, double* dpi,
 
   Parameters
   ----------
-  * X, Yinv, T : double[:]
-        Row-major matrices such that the Riemann matrix, Omega is equal to (X +
-        iY). T is the Cholesky decomposition of Y.
-  * x, y : double[:]
-        The real and imaginary parts of the input vector, z.
-  * S : double[:]
-        The set of points in ZZ^g over which to compute the finite sum
-  * deriv_real, deriv_imag : double[:]
-        The real and imaginary parts of the derivative directional vectors.
-  * nderivs : int
-        Number / order of derivatives.
-  * g : int
-        The dimension of the above matrices and vectors
-  * N : int
-       The number of points in ZZ^g over which to compute the sum
-       (= total number of elements in S / g)
+  X, Yinv, T : double[:]
+      Row-major matrices such that the Riemann matrix, Omega is equal to (X +
+      iY). T is the Cholesky decomposition of Y.
+  x, y : double[:]
+      The real and imaginary parts of the input vector, z.
+  S : double[:]
+      The set of points in ZZ^g over which to compute the finite sum
+  deriv_real, deriv_imag : double[:]
+      The real and imaginary parts of the derivative directional vectors.
+  nderivs : int
+      Number / order of derivatives.
+  g : int
+      The dimension of the above matrices and vectors
+  N : int
+     The number of points in ZZ^g over which to compute the sum
+     (= total number of elements in S / g)
 
   Returns
   -------
-  * fsum_real, fsum_imag : double*
-        The real and imaginary parts of the finite sum.
+  fsum_real, fsum_imag : double*
+      The real and imaginary parts of the finite sum.
 
 ******************************************************************************/
 void

--- a/abelfunctions/riemann_theta/finite_sum.c
+++ b/abelfunctions/riemann_theta/finite_sum.c
@@ -4,11 +4,20 @@
 
   Efficiently computing the finite sum part of the Riemann theta function.
 
+  Functions
+  ---------
+  exppart
+  normpart
+  finite_sum_without_derivatives
+  deriv_prod
+  finite_sum_with_derivatives
+
   Authors
   -------
 
-  *Chris Swierczewski (cswiercz@uw.edu) - September 2012
-  *Grady Williams (gradyrw@uw.edu) - October 2012
+  * Chris Swierczewski (@cswiercz) - September 2012, July 2016
+  * Grady Williams (@gradyrw) - October 2012
+  * Jeremy Upsal (@jupsal) - July 2016
 
 =============================================================================*/
 
@@ -40,40 +49,34 @@ extern "C" {
 double
 exppart(double* n, double* X, double* x, double* intshift, int g)
 {
-  double* tmp1 = (double*)malloc(g*sizeof(double));
-  double* tmp2 = (double*)malloc(g*sizeof(double));
+  double tmp1[g];
+  double tmp2[g];
   int i,j;
 
   // tmp1 = n - intshift
-  for (i = 0; i < g; i++) {
+  for (i = 0; i < g; i++)
     tmp1[i] = n[i] - intshift[i];
-  }
 
   // tmp2 = (1/2)X*(n-intshift)
   double sum;
   for (i = 0; i < g; i++) {
     sum = 0;
-    for (j = 0; j < g; j++) {
+    for (j = 0; j < g; j++)
       sum += X[i*g + j] * tmp1[j];
-    }
+
     tmp2[i] = sum/2.0;
   }
 
   // tmp2 = (1/2)*X(n-intshift) + x
-  for (i = 0; i < g; i++){
+  for (i = 0; i < g; i++)
     tmp2[i] = tmp2[i] + x[i];
-  }
 
   // ept = <tmp1,tmp2>
   double dot = 0;
-  for (i = 0; i < g; i++){
+  for (i = 0; i < g; i++)
     dot += tmp1[i]*tmp2[i];
-  }
-  double ept = 2* M_PI * dot;
 
-  free(tmp1);
-  free(tmp2);
-  return ept;
+  return 2* M_PI * dot;
 }
 
 
@@ -89,33 +92,29 @@ exppart(double* n, double* X, double* x, double* intshift, int g)
 double
 normpart(double* n, double* T, double* fracshift, int g)
 {
-  double* tmp1 = (double*)malloc(g*sizeof(double));
-  double* tmp2 = (double*)malloc(g*sizeof(double));
+  double tmp1[g];
+  double tmp2[g];
   int i,j;
 
   // tmp1 = n + fracshift
-  for (i = 0; i < g; i++) {
+  for (i = 0; i < g; i++)
     tmp1[i] = n[i] + fracshift[i];
-  }
 
   // tmp2 = T*(n+fracshift)
   double sum;
   for (i = 0; i < g; i++) {
     sum = 0;
-    for (j = 0; j < g; j++) {
+    for (j = 0; j < g; j++)
       sum += T[i*g + j] * tmp1[j];
-    }
+
     tmp2[i] = sum;
   }
 
   // norm = || T*(n + fracshift) || ^ 2
   double norm = 0;
-  for (i = 0; i < g; i++) {
+  for (i = 0; i < g; i++)
     norm += tmp2[i] * tmp2[i];
-  }
 
-  free(tmp1);
-  free(tmp2);
   return -M_PI * norm;
 }
 
@@ -150,19 +149,16 @@ normpart(double* n, double* T, double* fracshift, int g)
 
 void
 finite_sum_without_derivatives(double* fsum_real, double* fsum_imag,
-			       double* X, double* Yinv, double* T,
-		               double* x, double* y, double* S,
-	                       int g, int N)
+                               double* X, double* Yinv, double* T,
+                               double* x, double* y, double* S,
+                               int g, int N)
 {
   // compute the shifted vectors: shift = Yinv*y as well as its integer and
   // fractional parts
   int k,j;
-  double *shift;
-  double *intshift;
-  double *fracshift;
-  shift = (double*)malloc(g*sizeof(double));
-  intshift = (double*)malloc(g*sizeof(double));
-  fracshift = (double*)malloc(g*sizeof(double));
+  double shift[g];
+  double intshift[g];
+  double fracshift[g];
 
   // compute the following:
   //   * shift = Yinv*y;
@@ -171,9 +167,9 @@ finite_sum_without_derivatives(double* fsum_real, double* fsum_imag,
   double sum;
   for (k = 0; k < g; k++) {
     sum = 0;
-    for (j = 0; j < g; j++) {
+    for (j = 0; j < g; j++)
       sum += Yinv[k*g + j] * y[j];
-    }
+
     shift[k] = sum;
   }
 
@@ -202,11 +198,6 @@ finite_sum_without_derivatives(double* fsum_real, double* fsum_imag,
   //store values to poiners
   fsum_real[0] = real_total;
   fsum_imag[0] = imag_total;
-
-  //free any allocated vectors
-  free(shift);
-  free(intshift);
-  free(fracshift);
 }
 
 /******************************************************************************
@@ -245,17 +236,15 @@ deriv_prod(double* dpr, double* dpi,
            double* deriv_real, double* deriv_imag, int nderivs,
            int g)
 {
-  double* nmintshift = (double*)malloc(g*sizeof(double));
-
+  double nmintshift[g];
   double term_real, term_imag;
   double total_real, total_real_tmp;
   double total_imag, total_imag_tmp;
   int i,j;
 
   // compute n-intshift
-  for (i = 0; i < g; i++) {
+  for (i = 0; i < g; i++)
     nmintshift[i] = n[i] - intshift[i];
-  }
 
   /*
      Computes the dot product of each directional derivative and nmintshift.
@@ -270,6 +259,7 @@ deriv_prod(double* dpr, double* dpi,
       term_real += deriv_real[j + g*i] * nmintshift[j];
       term_imag += deriv_imag[j + g*i] * nmintshift[j];
     }
+
     /*
       Multiplies the dot product that was just computed with the product of all
       the previous terms. Total_real is the resulting real part of the sum, and
@@ -304,8 +294,6 @@ deriv_prod(double* dpr, double* dpi,
     dpr[0] = pi_mult * total_imag;
     dpi[0] = -pi_mult * total_real;
   }
-
-  free(nmintshift);
 }
 
 
@@ -342,9 +330,9 @@ deriv_prod(double* dpr, double* dpi,
 ******************************************************************************/
 void
 finite_sum_with_derivatives(double* fsum_real, double* fsum_imag,
-			    double* X, double* Yinv, double* T,
-			    double* x, double* y, double* S,
-		            double* deriv_real, double* deriv_imag,
+                            double* X, double* Yinv, double* T,
+                            double* x, double* y, double* S,
+                            double* deriv_real, double* deriv_imag,
                             int nderivs, int g, int N)
 {
   /*
@@ -352,19 +340,15 @@ finite_sum_with_derivatives(double* fsum_real, double* fsum_imag,
     fractional parts
   */
   int k,j;
-  double *shift;
-  double *intshift;
-  double *fracshift;
-  shift = (double*)malloc(g*sizeof(double));
-  intshift = (double*)malloc(g*sizeof(double));
-  fracshift = (double*)malloc(g*sizeof(double));
-
+  double shift[g];
+  double intshift[g];
+  double fracshift[g];
   double sum;
   for (k = 0; k < g; k++) {
     sum = 0;
-    for (j = 0; j < g; j++) {
+    for (j = 0; j < g; j++)
       sum += Yinv[k*g + j] * y[j];
-    }
+
     shift[k] = sum;
   }
 
@@ -376,8 +360,8 @@ finite_sum_with_derivatives(double* fsum_real, double* fsum_imag,
   // compute the finite sum
   double real_total = 0, imag_total = 0;
   double ept, npt, cpt, spt;
-  double* dpr = (double*)malloc(sizeof(double));
-  double* dpi = (double*)malloc(sizeof(double));
+  double dpr[1];
+  double dpi[1];
   double* n;
   dpr[0] = 0;
   dpi[0] = 0;
@@ -398,13 +382,6 @@ finite_sum_with_derivatives(double* fsum_real, double* fsum_imag,
   // store values to poiners
   fsum_real[0] = real_total;
   fsum_imag[0] = imag_total;
-
-  // free any allocated vectors
-  free(shift);
-  free(intshift);
-  free(fracshift);
-  free(dpr);
-  free(dpi);
 }
 
 #ifdef __cplusplus

--- a/abelfunctions/riemann_theta/radius.pyx
+++ b/abelfunctions/riemann_theta/radius.pyx
@@ -103,7 +103,8 @@ def radius(epsilon, T, derivs=[], accuracy_radius=5):
     if len(derivs) == 0:
         radius = radius0(epsilon, r, g)
     elif len(derivs) > 0:
-        radius = radiusN(epsilon, r, g, T, derivs, accuracy_radius)
+        radius = radiusN(epsilon, r, g, T, derivs,
+                         accuracy_radius=accuracy_radius)
     else:
         raise TypeError('Expected list of lists representing '
                 'directional derivative.')
@@ -163,7 +164,7 @@ def radius1(eps, r, g, T, deriv, accuracy_radius=5):
     return radius
 
 
-def radius2(eps, r, g, T, derivs, accuracy_radius):
+def radius2(eps, r, g, T, derivs, accuracy_radius=5):
     r"""Compute the radius with two derivatives.
 
     Notes
@@ -207,7 +208,7 @@ def radius2(eps, r, g, T, derivs, accuracy_radius):
 
 
 
-def radiusN(eps, r, g, T, derivs, accuracy_radius):
+def radiusN(eps, r, g, T, derivs, accuracy_radius=5):
     r"""Compute the radius with N deriviatives."""
     N = len(derivs)
     pi = numpy.pi

--- a/abelfunctions/riemann_theta/tests/test_radius.py
+++ b/abelfunctions/riemann_theta/tests/test_radius.py
@@ -1,0 +1,182 @@
+import unittest
+import numpy
+
+from abelfunctions.riemann_theta.radius import (
+    radius,
+    radius0,
+    radius1,
+    radius2,
+    radiusN,
+)
+
+class TestRadiusN(unittest.TestCase):
+    def test_vs_radius1_1e8(self):
+        # genus 3 example
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
+        rho = 0.9  # any rho is fine
+        eps = 1e-8
+
+        deriv = [1,0,0]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [0,1,0]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [0,0,1]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+    def test_vs_radius1_1e14(self):
+        # genus 3 example
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
+        rho = 0.9  # any rho is fine
+        eps = 1e-14
+
+        deriv = [1,0,0]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [0,1,0]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [0,0,1]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j]
+        R1 = radius1(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, [deriv])
+        self.assertAlmostEqual(R1, R2)
+
+    def test_vs_radius2_1e8(self):
+        # genus 3 example
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
+        rho = 0.9  # any rho is fine
+        eps = 1e-8
+
+        deriv = [[1,0,0], [1,0,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,1,0], [1,0,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,0,1], [1,0,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[1,0,0], [0,1,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,1,0], [0,1,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,0,1], [0,1,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[1,0,0], [0,0,1]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,1,0], [0,0,1]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,0,1], [0,0,1]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j],
+                 [0.7 + 0.8j, 0.9+1.0j, 1.1+1.2j]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+    def test_vs_radius2_1e14(self):
+        # genus 3 example
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
+        rho = 0.9  # any rho is fine
+        eps = 1e-14
+
+        deriv = [[1,0,0], [1,0,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,1,0], [1,0,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,0,1], [1,0,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[1,0,0], [0,1,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,1,0], [0,1,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,0,1], [0,1,0]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[1,0,0], [0,0,1]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,1,0], [0,0,1]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0,0,1], [0,0,1]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+
+        deriv = [[0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j],
+                 [0.7 + 0.8j, 0.9+1.0j, 1.1+1.2j]]
+        R1 = radius2(eps, rho, 3, T, deriv)
+        R2 = radiusN(eps, rho, 3, T, deriv)
+        self.assertAlmostEqual(R1, R2)
+

--- a/abelfunctions/riemann_theta/tests/test_theta.py
+++ b/abelfunctions/riemann_theta/tests/test_theta.py
@@ -171,7 +171,7 @@ class TestMaple(unittest.TestCase):
         self.assertLess(error_z4, 1e-8)
 
 
-    def test_second_derivatives(self):
+    def test_second_derivatives_oscpart(self):
         w = [0.2+0.5j, 0.3-0.1j, -0.1+0.2j]
         Omega = self.Omega3
 
@@ -198,6 +198,146 @@ class TestMaple(unittest.TestCase):
         self.assertLess(error_12, 1e-8)
         self.assertLess(error_22, 1e-8)
 
+    def test_third_derivatives_oscpart(self):
+        w = [0.2+0.5j, 0.3-0.1j, -0.1+0.2j]
+        Omega = self.Omega3
+
+        dVec_1 = [[1,0,0],[1,0,0],[1,0,0]]
+        dVec_2 = [[1,0,0],[0,1,0],[1,0,0]]
+        dVec_3 = [[1,0,0],[0,0,1],[0,1,0]]
+        dVec_4 = [[0,1,0],[0,0,1],[0,1,0]]
+        dVec_5 = [[0,0,1],[0,0,1],[0,0,1]]
+        dVec_6 = [[0,0,1],[0,1,0],[0,0,1]]
+        dVec_7 = [[1,2,3.1],[2.9,-0.3,1.0],[-20,13.3,0.6684]]
+
+        maple_1 = 88.96174663331488 + 12.83401972101860j
+        maple_2 = -5.963646070489819 + 9.261504506522976j
+        maple_3 = -1.347499363888600 + 0.5297607158965981j
+        maple_4 = 1.217499355198950 + 0.8449102496878512j
+        maple_5 = -15.58299545726265 - 0.4376346712347114j
+        maple_6 = -2.441570516715710 - 0.2535384980716853j
+        maple_7 = -2791.345600876934 + 1286.207313664481j
+
+        deriv_1 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_1)
+        deriv_2 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_2)
+        deriv_3 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_3)
+        deriv_4 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_4)
+        deriv_5 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_5)
+        deriv_6 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_6)
+        deriv_7 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_7)
+    
+        error_1 = abs(deriv_1 - maple_1)
+        error_2 = abs(deriv_2 - maple_2)
+        error_3 = abs(deriv_3 - maple_3)
+        error_4 = abs(deriv_4 - maple_4)
+        error_5 = abs(deriv_5 - maple_5)
+        error_6 = abs(deriv_6 - maple_6)
+        error_7 = abs(deriv_7 - maple_7)
+
+        self.assertLess(error_1, 1e-8)
+        self.assertLess(error_2, 1e-8)
+        self.assertLess(error_3, 1e-8)
+        self.assertLess(error_4, 1e-8)
+        self.assertLess(error_5, 1e-8)
+        self.assertLess(error_6, 1e-8)
+        self.assertLess(error_7, 1e-8)
+
+        # Genus 4 example
+        Omega = self.Omega4
+        w = [-0.37704918-0.18456279j, 0.63934426+0.42591413j,
+             0.54918033+0.09937996j, -0.21721311-0.07808426j]
+
+        dVec_1 = [[1,0,0,0],[1,0,0,0],[1,0,0,0]]
+        dVec_2 = [[1,0,0,0],[0,1,0,0],[0,0,1,0]]
+        dVec_3 = [[1,0,0,0],[0,0,1,0],[0,0,0,1]]
+        dVec_4 = [[1,0,0,0],[0,1,1,0],[1,0,0,1]]
+        dVec_5 = [[0,0,1,0],[0,1,1,0],[1,0,0,1]]
+        dVec_6 = [[0,0,1,0],[1,2,3,4],[1,0,0,1]]
+        dVec_7 = [[3.2,-9.8,0.004,-13.9],[0,2.4,0,4],[90.1,-12.93947,-1e-4,3]]
+
+        maple_1 = -67.14022021800414 - 50.25487358123665j
+        maple_2 = 6.220027066901749 - 16.96996479658767j
+        maple_3 = 14.42498231220689 + 16.30518807929409j
+        maple_4 = -35.67483045211793 - 18.14139876283777j
+        maple_5 = 53.25640352451774 + 18.93871689387491j
+        maple_6 = -185.6760275507559 - 93.99261766419004j
+        maple_7 = 239954.2751344823 + 129975.3988999572j
+
+        deriv_1 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_1)
+        deriv_2 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_2)
+        deriv_3 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_3)
+        deriv_4 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_4)
+        deriv_5 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_5)
+        deriv_6 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_6)
+        deriv_7 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_7)
+
+        error_1 = abs(deriv_1 - maple_1)
+        error_2 = abs(deriv_2 - maple_2)
+        error_3 = abs(deriv_3 - maple_3)
+        error_4 = abs(deriv_4 - maple_4)
+        error_5 = abs(deriv_5 - maple_5)
+        error_6 = abs(deriv_6 - maple_6)
+        error_7 = abs(deriv_7 - maple_7)
+
+        self.assertLess(error_1, 1e-8)
+        self.assertLess(error_2, 1e-8)
+        self.assertLess(error_3, 1e-8)
+        self.assertLess(error_4, 1e-8)
+        self.assertLess(error_5, 1e-8)
+        self.assertLess(error_6, 1e-8)
+        self.assertLess(error_7, 1e-8)
+
+
+    def test_sixth_derivatives(self):
+        w = [0.2+0.5j, 0.3-0.1j, -0.1+0.2j]
+        Omega = self.Omega3
+        
+        dVec_1 = [[1,0,0],[1,0,0],[0,1,0],[0,0,1],[0,0,1],[0,1,0]]
+        dVec_2 = [[1,2,3],[4,5,6],[0.7,0.8,0.9],[0.8,0.7,0.6],[5,4,3],[2,1,0]]
+        #dVec_3 = [[-17.3, 6.2, 0],[3.4, 3, 1],[-9,-0.001, 2], 
+        #        [1e-2, 0, 19],[210, 0.5, 1.2],[31.323, 0.3, 3]]
+        #dVec_4 = [[1,2,3],[4,5,6],[7,8,9],[8,7,6],[5,4,3],[2,1,0]]
+        # Neither of the above two examples pass the tests. It appears
+        # that for higher order derivatives, if the norm of the directional
+        # derivative is too large  
+
+        maple_1 = 42.73836471691125 + 235.2990585642670j
+        maple_2 = 0.2152838084588008*10**7 - 0.3287239590246880*10**7*1j
+        #maple_3 = 0.2232644817692030*10**12 - 0.1226563725159786*10**12*1j
+        #maple_4 = 0.2152838084588008*10**9 - 0.3287239590246880*10**9*1j
+
+        deriv_1 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_1)
+        deriv_2 = RiemannTheta.oscillatory_part(w, Omega, 
+                epsilon=1e-14, derivs=dVec_2)
+        #deriv_3 = RiemannTheta.oscillatory_part(w, Omega, 
+        #        epsilon=1e-14, derivs=dVec_3)
+        #deriv_4 = RiemannTheta.oscillatory_part(w, Omega, 
+        #        epsilon=1e-14, derivs=dVec_4)
+
+        error_1 = abs(deriv_1 - maple_1)
+        error_2 = abs(deriv_2 - maple_2)
+        #error_3 = abs(deriv_3 - maple_3)
+        #error_4 = abs(deriv_4 - maple_4)
+
+        self.assertLess(error_1, 1e-8)
+        self.assertLess(error_2, 1e-8)
+        #self.assertLess(error_3, 1e-8)
+        #self.assertLess(error_4, 1e-8)
 
 class TestRiemannThetaValues(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
A generalization of theorems 3,5,7 of [CRTF] is used to find the radius needed for computing N directional derivatives of the Riemann Theta Function. 

### Goals

- [x] Generalize radius calculation in `radius.pyx`.
- [x] Generalize derivative evaluation in `RiemannTheta`