### PR TITLE
Bugfix/newton warning

### DIFF
--- a/abelfunctions/riemann_surface_path.py
+++ b/abelfunctions/riemann_surface_path.py
@@ -933,7 +933,7 @@ def newton(df, xip1, yij):
         # if df is not invertible then we are at a critical point.
         df1y = df1(xip1,yij)
         if numpy.abs(df1y) < 1e-14:
-            return yij
+            break
         step = df0(xip1,yij) / df1y
         yij = yij - step
 

--- a/abelfunctions/riemann_surface_path.py
+++ b/abelfunctions/riemann_surface_path.py
@@ -35,6 +35,8 @@ Contents
 --------
 """
 
+import warnings
+
 import numpy
 import scipy
 from abelfunctions.divisor import DiscriminantPlace

--- a/abelfunctions/riemann_surface_path.py
+++ b/abelfunctions/riemann_surface_path.py
@@ -925,6 +925,8 @@ def newton(df, xip1, yij):
     df0 = df[0]
     df1 = df[1]
     step = numpy.complex(1.0)
+    maxIter = 1000
+    numIter = 0
     while numpy.abs(step) > 1e-14:
         # if df is not invertible then we are at a critical point.
         df1y = df1(xip1,yij)
@@ -932,6 +934,11 @@ def newton(df, xip1, yij):
             return yij
         step = df0(xip1,yij) / df1y
         yij = yij - step
+
+        numIter += 1
+        if numIter >= maxIter:
+            warnings.warn('Newton failed to converge after %d iterations. Final step size: %g' % (maxIter, numpy.abs(step)))
+            break
     return yij
 
 

--- a/abelfunctions/riemann_surface_path.pyx
+++ b/abelfunctions/riemann_surface_path.pyx
@@ -40,6 +40,8 @@ Contents
 --------
 """
 
+import warnings
+
 import numpy
 cimport numpy
 cimport cython
@@ -988,14 +990,21 @@ cdef complex newton(Wrapper_el[:] df, complex xip1, complex yij):
     cdef Wrapper_el df1 = df[1]
     cdef complex step = 1.0
     cdef complex df1y
+    cdef int maxIter = 1000
+    cdef int numIter = 0
     while cabs(step) > 1e-14:
         # if df is not invertible then we are at a critical point
         df1y = df1(xip1, yij)
         if cabs(df1y) < 1e-14:
-            return yij
+            break
         step = df0(xip1, yij)
         step = step / df1y
         yij = yij - step
+
+        numIter += 1
+        if numIter >= maxIter:
+            warnings.warn('Newton failed to converge after %d iterations. Final step size: %g' % (maxIter, cabs(step)))
+            break
     return yij
 
 


### PR DESCRIPTION
I found that the Newton iteration was causing the hang because the step size stopped decreasing just before reaching the `1e-14` cutoff.

This change adds a maximum iteration count and warns the user if the limit is reached.

closes #148 