### PR TITLE
Allow user to specify custom holomorphic differential basis

### DIFF
--- a/abelfunctions/abelmap.py
+++ b/abelfunctions/abelmap.py
@@ -385,7 +385,7 @@ class AbelMap_Function(object):
             value = numpy.zeros(genus, dtype=numpy.complex)
         else:
             gamma = X.path(P)
-            omega = X.holomorphic_differentials()
+            omega = X.differentials
             value = numpy.array([X.integrate(omegai,gamma)
                                  for omegai in omega], dtype=numpy.complex)
         return value

--- a/abelfunctions/differentials.py
+++ b/abelfunctions/differentials.py
@@ -245,6 +245,46 @@ def differentials(RS):
     return diffs
 
 
+def validate_differentials(differential_list, genus):
+    """Confirm that the proposed differentials have correct properties.
+
+    Parameters
+    ----------
+    diff_list: list
+        A list of Differentials whose properties are to be validated
+    genus: int
+        Genus of the Riemann surface
+
+    Returns
+    -------
+    is_valid: bool
+        A bool indicating whether the differentials are valid
+
+    Notes
+    -----
+    The present conditions are very general. More detailed tests will likely
+    be added in the future.
+    """
+
+    is_valid = True
+    try:
+        # Check types
+        assert(all(isinstance(diff, Differential) for diff in differential_list))
+
+        # Check that the number of differentials matches the genus
+        assert(len(differential_list) == genus)
+
+        # Check that they are all defined on the same surface
+        if len(differential_list) > 0:
+            riemann_surface = differential_list[0].RS
+            assert(all(diff.RS is riemann_surface for diff in differential_list))
+
+    except AssertionError:
+        is_valid = False
+
+    return is_valid
+
+
 class Differential:
     """A differential one-form which can be defined on a Riemann surface.
 

--- a/abelfunctions/riemann_constant_vector.py
+++ b/abelfunctions/riemann_constant_vector.py
@@ -302,7 +302,7 @@ def canonical_divisor(X):
     rewrite this algorithm so that it picks a "local best" canonical divisor.
 
     """
-    holomorphic_oneforms = X.holomorphic_oneforms()
+    holomorphic_oneforms = X.differentials
     canonical_divisors = [omega.valuation_divisor()
                           for omega in holomorphic_oneforms]
 

--- a/abelfunctions/tests/test_riemann_constant_vector.py
+++ b/abelfunctions/tests/test_riemann_constant_vector.py
@@ -75,7 +75,7 @@ class TestRCVCanonical(AbelfunctionsTestCase):
         g = self.X11.genus()
         assert g == 4
 
-        oneforms = self.X11.holomorphic_oneforms()
+        oneforms = self.X11.holomorphic_differentials()
         degree = oneforms[0].valuation_divisor().degree
         self.assertEqual(degree,2*g-2)
 
@@ -93,7 +93,7 @@ class TestRCVCanonical(AbelfunctionsTestCase):
         J = Jacobian(X)
         g = X.genus()
         P0 = X.base_place
-        oneforms = X.holomorphic_oneforms()
+        oneforms = X.holomorphic_differentials()
         C = oneforms[0].valuation_divisor()
         W = 2*RiemannConstantVector(P0) + AbelMap(C)
         self.assertLess(norm(J(W)),1e-7)
@@ -103,7 +103,7 @@ class TestRCVCanonical(AbelfunctionsTestCase):
         J = Jacobian(X)
         g = X.genus()
         P0 = X.base_place
-        oneforms = X.holomorphic_oneforms()
+        oneforms = X.holomorphic_differentials()
         C = oneforms[1].valuation_divisor()
         W = 2*RiemannConstantVector(P0) + AbelMap(C)
         self.assertLess(norm(J(W)),1e-7)
@@ -113,7 +113,7 @@ class TestRCVCanonical(AbelfunctionsTestCase):
         J = Jacobian(X)
         g = X.genus()
         P0 = X.base_place
-        oneforms = X.holomorphic_oneforms()
+        oneforms = X.holomorphic_differentials()
         C = oneforms[2].valuation_divisor()
         W = 2*RiemannConstantVector(P0) + AbelMap(C)
         self.assertLess(norm(J(W)),1e-7)
@@ -123,7 +123,7 @@ class TestRCVCanonical(AbelfunctionsTestCase):
         J = Jacobian(X)
         g = X.genus()
         P0 = X.base_place
-        oneforms = X.holomorphic_oneforms()
+        oneforms = X.holomorphic_differentials()
         C = oneforms[3].valuation_divisor()
         W = 2*RiemannConstantVector(P0) + AbelMap(C)
         self.assertLess(norm(J(W)),1e-7)

--- a/abelfunctions/tests/test_riemann_surface.py
+++ b/abelfunctions/tests/test_riemann_surface.py
@@ -15,3 +15,27 @@ class TestConstruction(AbelfunctionsTestCase):
         places = X(-3)
         for bi in X.branch_points:
             places = X(bi)
+
+    def test_differential_property(self):
+        X = RiemannSurface(self.f2)
+
+        # Test initial value
+        self.assertIsNone(X._user_differentials)
+
+        # Test default property
+        diffs = X.differentials
+        self.assertTrue(len(diffs) == X.genus())
+
+        # Test invalid set
+        with self.assertRaises(ValueError):
+            X.differentials = []
+
+        # Test valid set
+        X.differentials = diffs[::-1]
+        self.assertIsNotNone(X._user_differentials)
+        for a, b in zip(diffs[::-1], X.differentials):
+            self.assertIs(a, b)
+
+        # Test clear
+        X.differentials = None
+        self.assertIsNone(X._user_differentials)

--- a/doc/GettingStarted.md
+++ b/doc/GettingStarted.md
@@ -27,7 +27,7 @@ sage: X.genus()
 We can compute a basis for the space of holomorphic differentials on a Riemann surface. The affine part of the differentials are displayed when computed.
 
 ```python
-sage: differentials = X.holomorphic_differentials()
+sage: differentials = X.differentials
 sage: for omega in differentials:
   ...     print omega
 x*y/(2*x^3 + 3*y^2)


### PR DESCRIPTION
This permits the user to override the default `holomorphic_differentials`
basis and replace it with their own. Weak validation is performed on the
inputs by promoting `RiemannSurface.differentials` to a property with a
few basic checks on the properties of the inputs.

Also removes one of the aliases for `RiemannSurface.holomorphic_differentials`
to simplify the interface.

Resolves: #152 