### PR TITLE
Sage 8.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,19 @@ matrix:
         - SAGE_TARBALL=sage-8.0-Ubuntu_14.04-x86_64.tar.bz2
         - SAGE_SERVER=http://mirrors.mit.edu/sage/linux/64bit
       dist: trusty
+    - os: linux
+      env:
+        - SAGE_TARBALL=sage-8.1-Ubuntu_14.04-x86_64.tar.bz2
+        - SAGE_SERVER=http://mirrors.mit.edu/sage/linux/64bit
+      dist: trusty
     - os: osx
       env:
         - SAGE_TARBALL=sage-8.0-OSX_10.12.6-x86_64.tar.bz2
+        - SAGE_SERVER=http://mirrors.mit.edu/sage/osx/intel
+      osx_image: xcode9.1  # OSX 10.12
+    - os: osx
+      env:
+        - SAGE_TARBALL=sage-8.1-OSX_10.12.6-x86_64.tar.bz2
         - SAGE_SERVER=http://mirrors.mit.edu/sage/osx/intel
       osx_image: xcode9.1  # OSX 10.12
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,12 @@ matrix:
       env:
         - SAGE_TARBALL=sage-8.0-OSX_10.12.6-x86_64.tar.bz2
         - SAGE_SERVER=http://mirrors.mit.edu/sage/osx/intel
-      osx_image: xcode9.1  # OSX 10.12
+      osx_image: xcode9.2  # OSX 10.12
     - os: osx
       env:
         - SAGE_TARBALL=sage-8.1-OSX_10.12.6-x86_64.tar.bz2
         - SAGE_SERVER=http://mirrors.mit.edu/sage/osx/intel
-      osx_image: xcode9.1  # OSX 10.12
+      osx_image: xcode9.2  # OSX 10.12
 
 
 before_install:

--- a/abelfunctions/tests/test_puiseux.py
+++ b/abelfunctions/tests/test_puiseux.py
@@ -13,10 +13,9 @@ from abelfunctions.puiseux import (
 from abelfunctions.puiseux_series_ring import PuiseuxSeriesRing
 from abelfunctions.tests.test_abelfunctions import AbelfunctionsTestCase
 
-from sage.all import SR
+from sage.all import SR, xgcd
 from sage.calculus.functional import taylor
 from sage.calculus.var import var
-from sage.rings.arith import xgcd
 from sage.rings.laurent_series_ring import LaurentSeriesRing
 from sage.rings.rational_field import QQ
 from sage.rings.qqbar import QQbar

--- a/runtests.py
+++ b/runtests.py
@@ -95,7 +95,7 @@ def runtests(argv):
             result = runner.run(suite)
             errno = not result.wasSuccessful()
 
-        sys.exit(errno)
+    sys.exit(errno)
 
 if __name__ == '__main__':    
     # run tests and suppress warnings (particularly from PARI)

--- a/setup.py
+++ b/setup.py
@@ -25,11 +25,9 @@ import unittest
 from distutils.core import setup, Command
 from distutils.extension import Extension
 from Cython.Build import cythonize
-from numpy.distutils.misc_util import get_numpy_include_dirs
 
 # raise error if the user is not using Sage to compile
 try:
-    from sage.env import sage_include_directories
     SAGE_ROOT = os.environ['SAGE_ROOT']
 except (ImportError, KeyError):
     raise EnvironmentError('abelfunctions must be built using Sage:\n\n'
@@ -74,14 +72,8 @@ ext_modules = [
     ]
 
 # parameters for all extension modules:
-#
-# * most modules depend on Sage and Numpy. Provide include directories.
 # * disable warnings in gcc step
-INCLUDES = sage_include_directories()
-INCLUDES_NUMPY = get_numpy_include_dirs()
 for mod in ext_modules:
-    mod.include_dirs.extend(INCLUDES)
-    mod.include_dirs.extend(INCLUDES_NUMPY)
     mod.extra_compile_args.append('-w')
     mod.extra_compile_args.append('-std=c99')
 

--- a/setup.py
+++ b/setup.py
@@ -25,9 +25,11 @@ import unittest
 from distutils.core import setup, Command
 from distutils.extension import Extension
 from Cython.Build import cythonize
+from numpy.distutils.misc_util import get_numpy_include_dirs
 
 # raise error if the user is not using Sage to compile
 try:
+    from sage.env import sage_include_directories
     SAGE_ROOT = os.environ['SAGE_ROOT']
 except (ImportError, KeyError):
     raise EnvironmentError('abelfunctions must be built using Sage:\n\n'
@@ -72,8 +74,14 @@ ext_modules = [
     ]
 
 # parameters for all extension modules:
+#
+# * most modules depend on Sage and Numpy. Provide include directories.
 # * disable warnings in gcc step
+INCLUDES = sage_include_directories()
+INCLUDES_NUMPY = get_numpy_include_dirs()
 for mod in ext_modules:
+    mod.include_dirs.extend(INCLUDES)
+    mod.include_dirs.extend(INCLUDES_NUMPY)
     mod.extra_compile_args.append('-w')
     mod.extra_compile_args.append('-std=c99')
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ import unittest
 from distutils.core import setup, Command
 from distutils.extension import Extension
 from Cython.Distutils import build_ext
+from Cython.Build import cythonize
 from numpy.distutils.misc_util import get_numpy_include_dirs
 
 # raise error if the user is not using Sage to compile
@@ -177,7 +178,7 @@ setup(
     url = 'https://github.com/cswiercz/abelfunctions',
     license = 'GPL v2+',
     packages = packages,
-    ext_modules = ext_modules,
+    ext_modules = cythonize(ext_modules),
     platforms = ['all'],
     cmdclass = {'clean':clean, 'build_ext':build_ext}
 )

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ import shutil
 import unittest
 from distutils.core import setup, Command
 from distutils.extension import Extension
-from Cython.Distutils import build_ext
 from Cython.Build import cythonize
 from numpy.distutils.misc_util import get_numpy_include_dirs
 
@@ -180,5 +179,5 @@ setup(
     packages = packages,
     ext_modules = cythonize(ext_modules),
     platforms = ['all'],
-    cmdclass = {'clean':clean, 'build_ext':build_ext}
+    cmdclass = {'clean':clean}
 )

--- a/setup.py
+++ b/setup.py
@@ -43,39 +43,33 @@ ext_modules = [
     Extension('abelfunctions.complex_path',
               sources=[
                   os.path.join('abelfunctions',
-                               'complex_path.pyx')],
-              extra_compile_args = ['-std=c99'],
+                               'complex_path.pyx')]
           ),
     Extension('abelfunctions.riemann_surface_path',
               sources=[
                   os.path.join('abelfunctions',
-                               'riemann_surface_path.pyx')],
-              extra_compile_args = ['-std=c99'],
+                               'riemann_surface_path.pyx')]
           ),
     Extension('abelfunctions.puiseux_series_ring_element',
               sources=[
                   os.path.join('abelfunctions',
-                               'puiseux_series_ring_element.pyx')],
-              extra_compile_args = ['-std=c99'],
+                               'puiseux_series_ring_element.pyx')]
           ),
     Extension('abelfunctions.riemann_theta.radius',
               sources=[os.path.join('abelfunctions','riemann_theta',
                                     'lll_reduce.c'),
                        os.path.join('abelfunctions','riemann_theta',
-                                    'radius.pyx')],
-              extra_compile_args = ['-std=c99'],
+                                    'radius.pyx')]
           ),
     Extension('abelfunctions.riemann_theta.integer_points',
               sources=[os.path.join('abelfunctions','riemann_theta',
-                                    'integer_points.pyx')],
-              extra_compile_args = ['-std=c99'],
+                                    'integer_points.pyx')]
           ),
     Extension('abelfunctions.riemann_theta.riemann_theta',
               sources=[os.path.join('abelfunctions','riemann_theta',
                                     'finite_sum.c'),
                        os.path.join('abelfunctions','riemann_theta',
-                                    'riemann_theta.pyx')],
-              extra_compile_args = ['-std=c99'],
+                                    'riemann_theta.pyx')]
           ),
     ]
 
@@ -89,6 +83,7 @@ for mod in ext_modules:
     mod.include_dirs.extend(INCLUDES)
     mod.include_dirs.extend(INCLUDES_NUMPY)
     mod.extra_compile_args.append('-w')
+    mod.extra_compile_args.append('-std=c99')
 
 packages = [
     'abelfunctions',


### PR DESCRIPTION
Updates Travis-CI to test Sage 8.1 as well as 8.0 and fixes #154.

As pointed out in #142 Sage 8.1 moved `cython_metaclass.h` causing an error on installation when the header file was not found.  One possible solution was to add to `setup.py`
```Python
mod.include_dirs.extend([SAGE_ROOT+'/src/sage/cpython'])
```
but using `cythonize` (which [seems](https://trac.sagemath.org/ticket/22461) [recommended](http://cython.readthedocs.io/en/latest/src/userguide/source_files_and_compilation.html) anyway?) also finds the header file and should continue to do so if it gets moved again.