### PR TITLE
Fix riemann theta

### DIFF
--- a/abelfunctions/riemann_theta/radius.pyx
+++ b/abelfunctions/riemann_theta/radius.pyx
@@ -103,10 +103,10 @@ def radius(epsilon, T, derivs=[], accuracy_radius=5):
         Riemann theta function to desired accuracy.
 
     """
-    # compute the LLL-reduction of T
+    # compute the LLL-reduction of sqrt(pi)*T
     T = numpy.array(T, dtype=numpy.double)
     g = T.shape[0]
-    U = lll(T)
+    U = lll(sqrt(numpy.pi)*T)
     r = min(norm(U[:,i]) for i in range(g))
 
     if len(derivs) == 0:
@@ -130,7 +130,8 @@ def radius0(eps, r, g):
         Requested accuracy.
     r : double
         The length of the shortest lattice vector in the LLL reduction of the
-        Cholesky decomposition of the imaginary part of the Riemann matrix.
+        Cholesky decomposition of the imaginary part of the Riemann matrix
+        times sqrt(pi).
     g : int
         The genus / problem size.
 
@@ -158,7 +159,8 @@ def radiusN(eps, r, g, T, derivs, accuracy_radius=5):
         Requested accuracy.
     r : double
         The length of the shortest lattice vector in the LLL reduction of the
-        Cholesky decomposition of the imaginary part of the Riemann matrix.
+        Cholesky decomposition of the imaginary part of the Riemann matrix
+        times sqrt(pi).
     g : int
         The genus / problem size.
     T : matrix

--- a/abelfunctions/riemann_theta/radius.pyx
+++ b/abelfunctions/riemann_theta/radius.pyx
@@ -230,7 +230,7 @@ def radius1(eps, r, g, T, deriv, accuracy_radius=5):
     lhs = (eps*(r/2.)**g) / (sqrt(pi)*g*normderiv*normTinv)
 
     # define lower bound (guess) and attempt to solve for the radius
-    lbnd = sqrt(g+2+sqrt(g**2+8)) + r
+    lbnd = (sqrt(g+2+sqrt(g**2+8)) + r)/2.
     def rhs(ins):
         A = gamma((g+1)/2.) * gammaincc((g+1)/2., ins)
         B = sqrt(pi) * normTinv * L * gamma(g/2.) * gammaincc(g/2., ins)

--- a/abelfunctions/riemann_theta/radius.pyx
+++ b/abelfunctions/riemann_theta/radius.pyx
@@ -141,7 +141,7 @@ def radius0(eps, r, g):
         Riemann theta function to desired accuracy.
 
     """
-    lhs = eps * (2./g) * (r/2.)**g * gamma(g/2.)
+    lhs = eps * (2./g) * (r/2.)**g / gamma(g/2.)
     ins = gammainccinv(g/2.,lhs)
     R = sqrt(ins) + r/2.
     S = (sqrt(2.*g)+r)/2.

--- a/abelfunctions/riemann_theta/radius.pyx
+++ b/abelfunctions/riemann_theta/radius.pyx
@@ -272,7 +272,7 @@ def radius2(eps, r, g, T, derivs, accuracy_radius=5):
     lhs = (eps*(r/2.0)**g) / (2*pi*g*prodnormderiv*normTinv**2)
 
     # define lower bound (guess) and attempt to solve for the radius
-    lbnd = sqrt(g+4+sqrt(g**2+16)) + r
+    lbnd = (sqrt(g+4+sqrt(g**2+16)) + r)/2.
     def rhs(ins):
         A = gamma((g+2)/2.) * gammaincc((g+2)/2.,ins)
         B = 2*L*sqrt(pi) * normTinv * gamma((g+1)/2.) * gammaincc((g+1)/2.,ins)

--- a/abelfunctions/riemann_theta/tests/test_theta.py
+++ b/abelfunctions/riemann_theta/tests/test_theta.py
@@ -384,6 +384,15 @@ class TestRiemannThetaValues(unittest.TestCase):
             error = abs(R - R_actual)
             self.assertLess(error, 1e-8)
 
+    def test_issue159(self):
+        Omega = [[10j]]
+        z = [5j]
+
+        theta_actual = 2
+        theta = RiemannTheta(z,Omega)
+        error = abs(theta - theta_actual)
+        self.assertLess(error, 1e-8)
+
     def test_gradient(self):
         Omega = self.Omega3
 

--- a/abelfunctions/riemann_theta/tests/test_theta.py
+++ b/abelfunctions/riemann_theta/tests/test_theta.py
@@ -377,7 +377,8 @@ class TestRiemannThetaValues(unittest.TestCase):
         Y = Omega.imag
         T = cholesky(Y).T
 
-        R_actual = 5.01708695504
+        # Check that the radius is consistent when repeatedly computed
+        R_actual = radius(1e-8,T)
         for _ in range(1000):
             R = radius(1e-8,T)
             error = abs(R - R_actual)


### PR DESCRIPTION
Fixes issues related to the Riemann theta function, specifically the determination of R, the radius of the bounding ellipsoid used to truncate the Riemann theta function to desired accuracy.

`r` should be the shortest distance between two points of the lattice vector \sqrt{pi}T(n+[[Y^{-1}y]]) but it seems like abelfunctions missed the \sqrt{pi} off.

The definition of gamma in [CRTF] paper is equal to scipy's `gammaincc * gamma(g/2)` so need to divide `lhs` by `gamma(g/2)` before taking the inverse, `gammainccinv`, also defined by scipy.

Fixes #159