### PR TITLE
Update installation instructions

### DIFF
--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -1,26 +1,43 @@
 # Installation
 
-Abelfunctions requires Sage 8.0 or later ([www.sagemath.org](http://www.sagemath.org)). Sage makes it relatively easy to build and run the code.
+Abelfunctions requires [Sage (SageMath)](http://www.sagemath.org) 8.0 or later.
+Sage makes it relatively easy to build and run the code.
 
-> **Note:** Depending on your system one of the below installation methods may not work. I"m not sure what is causing this. Any contributions to the installation method (via `setup.py`) is greatly appreciated.
+> **Note:** Depending on your system one of the below installation methods
+may not work. I'm not sure what is causing this. Any contributions to the
+installation method (via `setup.py`) is greatly appreciated.
 
 # Recommended Method
 
-1. Download Abelfunctions using [Git](https://git-scm.com) or by clicking on the *"Download Zip"* button on the right-hand side of the [repository page](https://github.com/abelfunctions/abelfunctions).
+In a terminal, run the following commands
+
+```bash
+$ sage --pip install git+https://github.com/abelfunctions/abelfunctions
+```
+
+# Alternate method
+
+1. Download Abelfunctions using [Git](https://git-scm.com) or by clicking
+   on the *"Download Zip"* button on the right-hand side of the
+   [repository page](https://github.com/abelfunctions/abelfunctions).
 2. Enter the top-level directory, the one containing `setup.py` and run
 
    ```
    $ sage setup.py install
    ```
-   
+
 # Alternate Method
 
 If the above does not work for whatever reason, try this instead:
 
-1. Download Abelfunctions using [Git](https://git-scm.com) or by clicking on the *"Download Zip"* button on the right-hand side of the [repository page](https://github.com/abelfunctions/abelfunctions).
+1. Download Abelfunctions using [Git](https://git-scm.com) or by clicking on
+   the *"Download Zip"* button on the right-hand side of the
+   [repository page](https://github.com/abelfunctions/abelfunctions).
 
-   a. In the latter case, make sure that the name of the directory containing the package is exactly `abelfunctions`, not something like `abelfunctions-master`; i.e., rename it if necessary.
-   
+   a. In the latter case, make sure that the name of the directory containing
+   the package is exactly `abelfunctions`, not something like
+   `abelfunctions-master`; i.e., rename it if necessary.
+
 2. Convert the entire project into a Sage SPKG:
 
    ```


### PR DESCRIPTION
Update installation instructions by recommending a simpler way to install with pip.

Keep the other installation options as alternate installation methods.