### PR TITLE
Stop testing sage older than 9.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,18 +13,6 @@ jobs:
       fail-fast: false
       matrix:
        include:
-         - SAGE_TARBALL: sage-8.6-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit/old
-         - SAGE_TARBALL: sage-8.7-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit/old
-         - SAGE_TARBALL: sage-8.8-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit/old
-         - SAGE_TARBALL: sage-8.9-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit/old
-         - SAGE_TARBALL: sage-9.0-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit/old
-         - SAGE_TARBALL: sage-9.1-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit
          - SAGE_TARBALL: sage-9.2-Ubuntu_18.04-x86_64.tar.bz2
            SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit
          - SAGE_TARBALL: sage-9.3-Ubuntu_18.04-x86_64.tar.bz2


### PR DESCRIPTION
The current Sage installation guide goes as far as saying "do not install a version of Sage older than 9.2" so since apparently Sage is not supporting these versions I don't think we should either.