### PR TITLE
Fix test warnings

### DIFF
--- a/abelfunctions/abelmap.py
+++ b/abelfunctions/abelmap.py
@@ -343,7 +343,7 @@ class AbelMap_Function(object):
         D = args[0]
         X = D.RS
         g = X.genus()
-        value = numpy.zeros(g, dtype=numpy.complex)
+        value = numpy.zeros(g, dtype=complex)
         for P,n in D:
             Pvalue = self._eval_primitive(P)
             value += n*Pvalue
@@ -382,12 +382,12 @@ class AbelMap_Function(object):
         X = P.RS
         genus = X.genus()
         if P == X.base_place:
-            value = numpy.zeros(genus, dtype=numpy.complex)
+            value = numpy.zeros(genus, dtype=complex)
         else:
             gamma = X.path(P)
             omega = X.differentials
             value = numpy.array([X.integrate(omegai,gamma)
-                                 for omegai in omega], dtype=numpy.complex)
+                                 for omegai in omega], dtype=complex)
         return value
 
 AbelMap = AbelMap_Function()

--- a/abelfunctions/differentials.py
+++ b/abelfunctions/differentials.py
@@ -328,9 +328,9 @@ class Differential:
         self.RS = RS
         self.differential = self.numer / self.denom
         self.numer_n = fast_callable(self.numer.change_ring(CC), vars=[x,y],
-                                     domain=numpy.complex)
+                                     domain=complex)
         self.denom_n = fast_callable(self.denom.change_ring(CC), vars=[x,y],
-                                     domain=numpy.complex)
+                                     domain=complex)
 
     def __repr__(self):
         return str(self.differential)
@@ -342,7 +342,7 @@ class Differential:
         r"""Evaluate the differential at the complex point :math:`(x,y)`.
         """
         val = self.numer_n(*args, **kwds) / self.denom_n(*args, **kwds)
-        return numpy.complex(val)
+        return complex(val)
 
     def centered_at_place(self, P, order=None):
         r"""Rewrite the differential in terms of the local coordinates at `P`.

--- a/abelfunctions/puiseux.py
+++ b/abelfunctions/puiseux.py
@@ -587,7 +587,7 @@ class PuiseuxTSeries(object):
         else:
             return (complex(self.center),
                     complex(self.xcoefficient),
-                    numpy.int(self.ramification_index))
+                    int(self.ramification_index))
     @property
     def order(self):
         return self._singular_order + self._regular_order

--- a/abelfunctions/puiseux.py
+++ b/abelfunctions/puiseux.py
@@ -585,8 +585,8 @@ class PuiseuxTSeries(object):
         if self.is_numerical:
             return self.xdata
         else:
-            return (numpy.complex(self.center),
-                    numpy.complex(self.xcoefficient),
+            return (complex(self.center),
+                    complex(self.xcoefficient),
                     numpy.int(self.ramification_index))
     @property
     def order(self):

--- a/abelfunctions/riemann_constant_vector.py
+++ b/abelfunctions/riemann_constant_vector.py
@@ -102,7 +102,7 @@ def initialize_half_lattice_vectors(X):
     half = list(product((0,0.5),repeat=g))
     half_lattice_vectors = numpy.array(
         [h1 + dot(Omega,h2) for h1 in half for h2 in half],
-        dtype=numpy.complex
+        dtype=complex
     )
     return half_lattice_vectors
 
@@ -394,7 +394,7 @@ def RiemannConstantVector(P, epsilon1=1e-6, epsilon2=1e-8, C=None):
     # shift by the abel map
     X = P.RS
     J = Jacobian(X)
-    g = numpy.complex(X.genus())
+    g = complex(X.genus())
     K0 = compute_K0(X, epsilon1, epsilon2, C)
     if P == X.base_place:
         return K0

--- a/abelfunctions/riemann_surface.py
+++ b/abelfunctions/riemann_surface.py
@@ -186,7 +186,7 @@ class RiemannSurface(object):
             alpha = QQbar(alpha)
             exact = True
         except TypeError:
-            alpha = numpy.complex(alpha)
+            alpha = complex(alpha)
             exact = False
         b = self.path_factory.closest_discriminant_point(alpha,exact=exact)
 
@@ -402,7 +402,7 @@ class RiemannSurface(object):
         # tau[i,j] = \int_{a_j} \omega_i,  j < g
         # tau[i,j] = \int_{b_j} \omega_i,  j >= g
         #
-        tau = numpy.zeros((g,2*g), dtype=numpy.complex)
+        tau = numpy.zeros((g,2*g), dtype=complex)
         for i in range(g):
             for j in range(2*g):
                 tau[i,j] = sum(linear_combinations[j,k] * c_periods[i][k]

--- a/abelfunctions/riemann_surface_path.py
+++ b/abelfunctions/riemann_surface_path.py
@@ -882,7 +882,7 @@ class RiemannSurfacePathPuiseux(RiemannSurfacePathPrimitive):
         tprim = complex((x0-alpha)/xcoefficient)**(1./e)
         unity = [numpy.exp(2.j*numpy.pi*k/abs(e)) for k in range(abs(e))]
         tall = [unity[k]*tprim for k in range(abs(e))]
-        ytprim = numpy.array([p.eval_y(tk) for tk in tall], dtype=numpy.complex)
+        ytprim = numpy.array([p.eval_y(tk) for tk in tall], dtype=complex)
         k = numpy.argmin(numpy.abs(ytprim - y0))
         tcoefficient = tall[k]
 
@@ -926,7 +926,7 @@ def newton(df, xip1, yij):
     """
     df0 = df[0]
     df1 = df[1]
-    step = numpy.complex(1.0)
+    step = complex(1.0)
     maxIter = 1000
     numIter = 0
     while numpy.abs(step) > 1e-14:

--- a/abelfunctions/riemann_surface_path.py
+++ b/abelfunctions/riemann_surface_path.py
@@ -874,7 +874,7 @@ class RiemannSurfacePathPuiseux(RiemannSurfacePathPrimitive):
         y0 = complex(self.gamma.y0[0])
         alpha = 0 if self.target_point == infinity else self.target_point
         xcoefficient = complex(p.xcoefficient)
-        e = numpy.int(p.ramification_index)
+        e = int(p.ramification_index)
 
         # the parameter of the path s \in [0,1] does not necessarily match with
         # the local coordinate t of the place. perform the appropriate scaling

--- a/abelfunctions/riemann_surface_path.pyx
+++ b/abelfunctions/riemann_surface_path.pyx
@@ -930,7 +930,7 @@ cdef class RiemannSurfacePathPuiseux(RiemannSurfacePathPrimitive):
         y0 = complex(self._y0[0])
         alpha = 0 if self.target_point == infinity else self.target_point
         xcoefficient = complex(p.xcoefficient)
-        e = numpy.int(p.ramification_index)
+        e = int(p.ramification_index)
 
         # the parameter of the path s \in [0,1] does not necessarily match with
         # the local coordinate t of the place. perform the appropriate scaling

--- a/abelfunctions/riemann_surface_path.pyx
+++ b/abelfunctions/riemann_surface_path.pyx
@@ -938,7 +938,7 @@ cdef class RiemannSurfacePathPuiseux(RiemannSurfacePathPrimitive):
         tprim = complex((x0-alpha)/xcoefficient)**(1./e)
         unity = [numpy.exp(2.j*numpy.pi*k/abs(e)) for k in range(abs(e))]
         tall = [unity[k]*tprim for k in range(abs(e))]
-        ytprim = numpy.array([p.eval_y(tk) for tk in tall], dtype=numpy.complex)
+        ytprim = numpy.array([p.eval_y(tk) for tk in tall], dtype=complex)
         k = numpy.argmin(numpy.abs(ytprim - y0))
         tcoefficient = tall[k]
 
@@ -1144,7 +1144,7 @@ cdef class RiemannSurfacePathSmale(RiemannSurfacePathPrimitive):
         f = riemann_surface.f.change_ring(CDF)
         x,y = f.parent().gens()
         df = [
-            fast_callable(f.derivative(y,k), vars=(x,y), domain=numpy.complex)
+            fast_callable(f.derivative(y,k), vars=(x,y), domain=complex)
             for k in range(degree+1)
         ]
         df = numpy.array(df, dtype=Wrapper_el)

--- a/abelfunctions/riemann_surface_path_factory.py
+++ b/abelfunctions/riemann_surface_path_factory.py
@@ -157,7 +157,7 @@ class RiemannSurfacePathFactory(object):
             x,y = self.riemann_surface.f.parent().gens()
             p = self.riemann_surface.f(self.base_point, y).univariate_polynomial()
             roots = p.roots(CDF, multiplicities=False)
-            base_sheets = numpy.array(roots, dtype=numpy.complex)
+            base_sheets = numpy.array(roots, dtype=complex)
         else:
             f = self.riemann_surface.f
             for sheet in base_sheets:
@@ -370,7 +370,7 @@ class RiemannSurfacePathFactory(object):
 
         # sanity check
         yend = gamma.get_y(1.0)[0]
-        if numpy.abs(yend - numpy.complex(P.y)) > 1.0e-8:
+        if numpy.abs(yend - complex(P.y)) > 1.0e-8:
             raise ValueError('Error in constructing Abel path.')
         return gamma
 

--- a/abelfunctions/riemann_theta/deprecated/box_points.py
+++ b/abelfunctions/riemann_theta/deprecated/box_points.py
@@ -30,7 +30,7 @@ def riemanntheta_high_dim(X, Yinv, T, z, g, rad, max_points = 10000000):
     num_final_partition = num_int_points - num_partitions*max_points
     osc_part = 0 + 0*1.j
     if (num_partitions > 0):
-        S = gpuarray.zeros(np.int(max_points * g), dtype=np.double)
+        S = gpuarray.zeros(int(max_points * g), dtype=np.double)
     print "Required number of iterations"
     print num_partitions
     print 
@@ -40,7 +40,7 @@ def riemanntheta_high_dim(X, Yinv, T, z, g, rad, max_points = 10000000):
         S = box_points(point_finder, max_points*p, max_points*(p+1),g,R, S)
         parRiemann.cache_intpoints(S, gpu_already=True)
         osc_part += parRiemann.compute_v_without_derivs(np.array([z]))
-    S = gpuarray.zeros(np.int((num_int_points - num_partitions*max_points)*g), dtype = np.double)
+    S = gpuarray.zeros(int((num_int_points - num_partitions*max_points)*g), dtype = np.double)
     print num_partitions*max_points,num_int_points
     S = box_points(point_finder, num_partitions*max_points, num_int_points, g, R,S)
     parRiemann.cache_intpoints(S,gpu_already = True)

--- a/abelfunctions/riemann_theta/riemann_theta.pyx
+++ b/abelfunctions/riemann_theta/riemann_theta.pyx
@@ -87,7 +87,7 @@ def oscillatory_part(z, Omega, epsilon, derivs, accuracy_radius, axis):
 
     # coerce z to a numpy array and determine the problem size: the genus g and
     # the number of vectors to compute
-    z = numpy.array(z, dtype=numpy.complex)
+    z = numpy.array(z, dtype=complex)
     if len(z.shape) == 1:
         num_vectors = 1
         g = len(z)
@@ -99,7 +99,7 @@ def oscillatory_part(z, Omega, epsilon, derivs, accuracy_radius, axis):
     # coerce Omega to a numpy array and extract the requested information: the
     # real part, inverse of the imaginary part, and the cholesky decomposition
     # of the imaginary part
-    Omega = numpy.array(Omega, dtype=numpy.complex)
+    Omega = numpy.array(Omega, dtype=complex)
     Y = Omega.imag
     _T = numpy.linalg.cholesky(Y).T
     X = numpy.ascontiguousarray(Omega.real)
@@ -115,11 +115,11 @@ def oscillatory_part(z, Omega, epsilon, derivs, accuracy_radius, axis):
     # set up storage locations and vectors
     real = <double*>malloc(sizeof(double))
     imag = <double*>malloc(sizeof(double))
-    values = numpy.zeros(num_vectors, dtype=numpy.complex)
+    values = numpy.zeros(num_vectors, dtype=complex)
 
     # get the derivatives
     if len(derivs):
-        derivs = numpy.array(derivs, dtype=numpy.complex).flatten()
+        derivs = numpy.array(derivs, dtype=complex).flatten()
         nderivs = len(derivs) / g
         derivs_real = numpy.ascontiguousarray(derivs.real, dtype=numpy.double)
         derivs_imag = numpy.ascontiguousarray(derivs.imag, dtype=numpy.double)
@@ -134,7 +134,7 @@ def oscillatory_part(z, Omega, epsilon, derivs, accuracy_radius, axis):
                                         &x[0], &y[0], &S[0,0],
                                         &derivs_real[0], &derivs_imag[0],
                                         nderivs, g, N)
-            value = numpy.complex(real[0] + 1.0j*imag[0])
+            value = complex(real[0] + 1.0j*imag[0])
             values[k] = value
     else:
         # compute the finite sum for each z-vector
@@ -145,7 +145,7 @@ def oscillatory_part(z, Omega, epsilon, derivs, accuracy_radius, axis):
             finite_sum_without_derivatives(real, imag,
                                            &X[0,0], &Yinv[0,0], &T[0,0],
                                            &x[0], &y[0], &S[0,0], g, N)
-            value = numpy.complex(real[0] + 1.0j*imag[0])
+            value = complex(real[0] + 1.0j*imag[0])
             values[k] = value
 
     if num_vectors == 1:
@@ -242,8 +242,8 @@ cdef class RiemannTheta_Function(object):
         # of Omega
         if len(numpy.shape(z)) == 1:
             z = [z]
-        z = numpy.array(z, dtype=numpy.complex)
-        Omega = numpy.array(Omega, dtype=numpy.complex)
+        z = numpy.array(z, dtype=complex)
+        Omega = numpy.array(Omega, dtype=complex)
         y = z.imag
         Yinv = numpy.linalg.inv(Omega.imag)
 
@@ -319,9 +319,9 @@ cdef class RiemannTheta_Function(object):
             gradient is listed along `axis`.
         """
         # get the genus and number of z-vectors
-        Omega = numpy.array(Omega, dtype=numpy.complex)
+        Omega = numpy.array(Omega, dtype=complex)
         g = Omega.shape[0]
-        gradients = numpy.zeros_like(z, dtype=numpy.complex)
+        gradients = numpy.zeros_like(z, dtype=complex)
 
         for i in range(g):
             # construct the direction derivative \partial z_i and compute the
@@ -414,14 +414,14 @@ cdef class RiemannTheta_Function(object):
             Hessian is indexed by the 0th coordinate.
         """
         # get the genus and number of z-vectors
-        Omega = numpy.array(Omega, dtype=numpy.complex)
+        Omega = numpy.array(Omega, dtype=complex)
         g = Omega.shape[0]
-        z = numpy.array(z, dtype=numpy.complex)
+        z = numpy.array(z, dtype=complex)
         if len(z.shape) == 1:
             n = 1
         else:
             n = z.shape[(axis+1) % 2]
-        hessians = numpy.zeros((n,g,g), dtype=numpy.complex)
+        hessians = numpy.zeros((n,g,g), dtype=complex)
 
         # since Riemann theta is analytic we only need to compute the lower
         # triangular portion of the Hessian and symmetrize

--- a/abelfunctions/riemann_theta/tests/test_radius.py
+++ b/abelfunctions/riemann_theta/tests/test_radius.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 import numpy
 
 from abelfunctions.riemann_theta.radius import (
@@ -9,174 +9,42 @@ from abelfunctions.riemann_theta.radius import (
     radiusN,
 )
 
-class TestRadiusN(unittest.TestCase):
-    def test_vs_radius1_1e8(self):
-        # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
-        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
-        rho = 0.9  # any rho is fine
-        eps = 1e-8
-
-        deriv = [1,0,0]
+@pytest.mark.parametrize('deriv', [
+    [1,0,0], 
+    [0,1,0], 
+    [0,0,1], 
+    [0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j]
+])
+@pytest.mark.parametrize('eps', [1e-8, 1e-14])
+def test_vs_radius1(deriv, eps):
+    # genus 3 example
+    T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
+    rho = 0.9  # any rho is fine
+    with pytest.warns(DeprecationWarning):
         R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
+    R2 = radiusN(eps, rho, 3, T, [deriv])
+    assert R1 == pytest.approx(R2)
 
-        deriv = [0,1,0]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
 
-        deriv = [0,0,1]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
-
-    def test_vs_radius1_1e14(self):
-        # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
-        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
-        rho = 0.9  # any rho is fine
-        eps = 1e-14
-
-        deriv = [1,0,0]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [0,1,0]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [0,0,1]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j]
-        R1 = radius1(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, [deriv])
-        self.assertAlmostEqual(R1, R2)
-
-    def test_vs_radius2_1e8(self):
-        # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
-        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
-        rho = 0.9  # any rho is fine
-        eps = 1e-8
-
-        deriv = [[1,0,0], [1,0,0]]
+@pytest.mark.parametrize('deriv', [
+    [[1,0,0], [1,0,0]], 
+    [[0,1,0], [1,0,0]], 
+    [[0,0,1], [1,0,0]], 
+    [[1,0,0], [0,1,0]], 
+    [[0,1,0], [0,1,0]], 
+    [[0,0,1], [0,1,0]], 
+    [[1,0,0], [0,0,1]],
+    [[0,1,0], [0,0,1]],
+    [[0,0,1], [0,0,1]],
+    [[0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j], [0.7 + 0.8j, 0.9+1.0j, 1.1+1.2j]]
+])
+@pytest.mark.parametrize('eps', [1e-8, 1e-14])
+def test_vs_radius2(deriv, eps):
+    # genus 3 example
+    T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
+    rho = 0.9  # any rho is fine
+    with pytest.warns(DeprecationWarning):
         R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,1,0], [1,0,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,0,1], [1,0,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[1,0,0], [0,1,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,1,0], [0,1,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,0,1], [0,1,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[1,0,0], [0,0,1]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,1,0], [0,0,1]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,0,1], [0,0,1]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j],
-                 [0.7 + 0.8j, 0.9+1.0j, 1.1+1.2j]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-    def test_vs_radius2_1e14(self):
-        # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
-        T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
-        rho = 0.9  # any rho is fine
-        eps = 1e-14
-
-        deriv = [[1,0,0], [1,0,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,1,0], [1,0,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,0,1], [1,0,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[1,0,0], [0,1,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,1,0], [0,1,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,0,1], [0,1,0]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[1,0,0], [0,0,1]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,1,0], [0,0,1]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0,0,1], [0,0,1]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
-
-        deriv = [[0.1 + 0.2j, 0.3+0.4j, 0.5+0.6j],
-                 [0.7 + 0.8j, 0.9+1.0j, 1.1+1.2j]]
-        R1 = radius2(eps, rho, 3, T, deriv)
-        R2 = radiusN(eps, rho, 3, T, deriv)
-        self.assertAlmostEqual(R1, R2)
+    R2 = radiusN(eps, rho, 3, T, deriv)
+    assert R1 == pytest.approx(R2)
 

--- a/abelfunctions/riemann_theta/tests/test_radius.py
+++ b/abelfunctions/riemann_theta/tests/test_radius.py
@@ -12,7 +12,7 @@ from abelfunctions.riemann_theta.radius import (
 class TestRadiusN(unittest.TestCase):
     def test_vs_radius1_1e8(self):
         # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
         T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
         rho = 0.9  # any rho is fine
         eps = 1e-8
@@ -39,7 +39,7 @@ class TestRadiusN(unittest.TestCase):
 
     def test_vs_radius1_1e14(self):
         # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
         T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
         rho = 0.9  # any rho is fine
         eps = 1e-14
@@ -66,7 +66,7 @@ class TestRadiusN(unittest.TestCase):
 
     def test_vs_radius2_1e8(self):
         # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
         T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
         rho = 0.9  # any rho is fine
         eps = 1e-8
@@ -124,7 +124,7 @@ class TestRadiusN(unittest.TestCase):
 
     def test_vs_radius2_1e14(self):
         # genus 3 example
-        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=numpy.complex)
+        z = numpy.array([0.2+0.5j, 0.3-0.1j, -0.1+0.2j], dtype=complex)
         T = numpy.diag([1,2,3]) + numpy.diag([4,5], k=1) + numpy.diag([6], k=2)
         rho = 0.9  # any rho is fine
         eps = 1e-14

--- a/abelfunctions/riemann_theta/tests/test_theta.py
+++ b/abelfunctions/riemann_theta/tests/test_theta.py
@@ -39,7 +39,7 @@ def thetag1(z,tau,N=2048):
     r"""Naive implementation of genus 1 theta function."""
     return sum(numpy.exp(numpy.pi*1.j*tau*n**2 + 2.j*numpy.pi*n*z)
                for n in range(-N,N))
-thetag1 = numpy.vectorize(thetag1, otypes=(numpy.complex,), excluded=(1,2))
+thetag1 = numpy.vectorize(thetag1, otypes=(complex,), excluded=(1,2))
 
 
 
@@ -48,7 +48,7 @@ class TestMaple(unittest.TestCase):
         self.Omega3 = numpy.array(
             [[1.j, 0.5, 0.5],
              [0.5, 1.j, 0.5],
-             [0.5, 0.5, 1.j]], dtype=numpy.complex)
+             [0.5, 0.5, 1.j]], dtype=complex)
         self.Omega4 = numpy.array([
             [ 0.39344262+0.79503971j, -0.75409836-0.36912558j,
               -0.44262295-0.02839428j,  0.20491803+0.26974562j],
@@ -344,7 +344,7 @@ class TestRiemannThetaValues(unittest.TestCase):
         self.Omega3 = numpy.array(
             [[1.j, 0.5, 0.5],
              [0.5, 1.j, 0.5],
-             [0.5, 0.5, 1.j]], dtype=numpy.complex)
+             [0.5, 0.5, 1.j]], dtype=complex)
         self.Omega4 = numpy.array(
             [[ 0.39344262+0.79503971j, -0.75409836-0.36912558j,
                -0.44262295-0.02839428j,  0.20491803+0.26974562j],
@@ -354,7 +354,7 @@ class TestRiemannThetaValues(unittest.TestCase):
               -0.37704918+0.68146261j, -0.91803279+0.45430841j],
              [ 0.20491803+0.26974562j, -0.43442623-0.15616852j,
                -0.91803279+0.45430841j, -1.27868852+0.88022254j]],
-            dtype=numpy.complex)
+            dtype=complex)
 
     def test_issue84_value(self):
         z = [0.5-1.10093687j, -0.11723434j]
@@ -406,7 +406,7 @@ class TestRiemannThetaValues(unittest.TestCase):
         dz0 = RiemannTheta(W,Omega,derivs=[[1,0,0]])
         dz1 = RiemannTheta(W,Omega,derivs=[[0,1,0]])
         dz2 = RiemannTheta(W,Omega,derivs=[[0,0,1]])
-        grad1 = numpy.zeros_like(W, dtype=numpy.complex)
+        grad1 = numpy.zeros_like(W, dtype=complex)
         grad1[:,0] = dz0
         grad1[:,1] = dz1
         grad1[:,2] = dz2
@@ -428,7 +428,7 @@ class TestRiemannThetaValues(unittest.TestCase):
         dz1 = RiemannTheta(W,Omega,derivs=[[0,1,0,0]])
         dz2 = RiemannTheta(W,Omega,derivs=[[0,0,1,0]])
         dz3 = RiemannTheta(W,Omega,derivs=[[0,0,0,1]])
-        grad1 = numpy.zeros_like(W, dtype=numpy.complex)
+        grad1 = numpy.zeros_like(W, dtype=complex)
         grad1[:,0] = dz0
         grad1[:,1] = dz1
         grad1[:,2] = dz2
@@ -533,7 +533,7 @@ class TestRiemannThetaValues(unittest.TestCase):
 
         values1 = RiemannTheta(z,tau,epsilon=1e-16)
         values2 = numpy.array([jtheta(3,wi,q) for wi in w],
-                              dtype=numpy.complex)
+                              dtype=complex)
 
         rel_error = abs((values1-values2)/values1)
         rel_error_avg = numpy.mean(rel_error)
@@ -545,7 +545,7 @@ class TestRiemannThetaValues(unittest.TestCase):
 
         values1 = RiemannTheta(z,tau,epsilon=1e-16)
         values2 = numpy.array([jtheta(3,wi,q) for wi in w],
-                              dtype=numpy.complex)
+                              dtype=complex)
 
         rel_error = abs((values1-values2)/values1)
         rel_error_avg = numpy.mean(rel_error)
@@ -555,7 +555,7 @@ class TestRiemannThetaValues(unittest.TestCase):
     #     Omega = numpy.array(
     #         [[1.0 + 1.15700539j, -1.0 - 0.5773502693j],
     #          [-1.0 - 0.5773502693j, 1.0 + 1.154700539j]],
-    #         dtype=numpy.complex)
+    #         dtype=complex)
 
     #     # first z-value
     #     z = numpy.array([1.0 - 1.0j, 1.0 + 1.0j])
@@ -585,7 +585,7 @@ class TestRiemannThetaValues(unittest.TestCase):
     #     Omega = numpy.array(
     #         [[1.0 + 1.15700539j, -1.0 - 0.5773502693j],
     #          [-1.0 - 0.5773502693j, 1.0 + 1.154700539j]],
-    #         dtype=numpy.complex)
+    #         dtype=complex)
 
     #     # first z-value
     #     z = numpy.array([1.0 - 1.0j, 1.0 + 1.0j])
@@ -615,7 +615,7 @@ class TestRiemannThetaValues(unittest.TestCase):
     # def test_value_at_point_1_derivs(self):
     #     Omega = numpy.array([[1.0 + 1.15700539j, -1.0 - 0.5773502693j],
     #                       [-1.0 - 0.5773502693j, 1.0 + 1.154700539j]],
-    #                      dtype=numpy.complex)
+    #                      dtype=complex)
 
     #     # test 1
     #     derivs = [[1,0]]
@@ -647,7 +647,7 @@ class TestRiemannThetaValues(unittest.TestCase):
     # def test_value_at_point_2_derivs(self):
     #     Omega = numpy.array([[1.0 + 1.15700539j, -1.0 - 0.5773502693j],
     #                       [-1.0 - 0.5773502693j, 1.0 + 1.154700539j]],
-    #                      dtype=numpy.complex)
+    #                      dtype=complex)
 
     #     # test 1
     #     derivs = [[1,0]]

--- a/abelfunctions/skeleton.py
+++ b/abelfunctions/skeleton.py
@@ -114,12 +114,12 @@ def frobenius_transform(A, g):
 
     """
     if not isinstance(A, numpy.matrix):
-        A = numpy.matrix(A, dtype=numpy.int)
+        A = numpy.matrix(A, dtype=int)
     K = A
     dim = K.shape[0]
 
     # the rank of an antisymmetric matrix is always even (equal to 2g)
-    T = numpy.eye(dim, dtype=numpy.int)
+    T = numpy.eye(dim, dtype=int)
 
     # create the block below the diagonal. make zeros everywhere else in the
     # first g columns
@@ -443,7 +443,7 @@ def intersection_matrix(final_edges, g):
     # the intersection matrix is anti-symmetric, so we only determine the
     # intersection numbers of the upper triangle
     num_final_edges = len(final_edges)
-    K = numpy.zeros((num_final_edges, num_final_edges), dtype=numpy.int)
+    K = numpy.zeros((num_final_edges, num_final_edges), dtype=int)
     for i in range(num_final_edges):
         ei = final_edges[i]
         for j in range(i+1,num_final_edges):
@@ -690,7 +690,7 @@ class Skeleton(object):
             The genus of the Riemann surface.
 
         """
-        self.genus = numpy.int(genus)
+        self.genus = int(genus)
         self.C = tretkoff_graph(base_point, base_sheets, monodromy_group)
 
         # compute the a-, b-, and c-cycles by calling self.homology()

--- a/abelfunctions/skeleton.py
+++ b/abelfunctions/skeleton.py
@@ -113,8 +113,8 @@ def frobenius_transform(A, g):
     output of the procedure is the transformation matrix alpha.
 
     """
-    if not isinstance(A, numpy.matrix):
-        A = numpy.matrix(A, dtype=int)
+    if not isinstance(A, numpy.ndarray):
+        A = numpy.array(A, dtype=int)
     K = A
     dim = K.shape[0]
 
@@ -182,7 +182,7 @@ def frobenius_transform(A, g):
     # result?  T * K * T.T = J where J has the gxg identity I in the
     # top right block and -I in the lower left block (the Jacobian
     # matrix)
-    J = numpy.dot(numpy.dot(T, numpy.matrix(A)), T.T)
+    J = numpy.dot(numpy.dot(T, A), T.T)
     for i in range(g):
         for j in range(g):
             if j==i+g and i<g:   val = 1

--- a/abelfunctions/tests/test_complex_path_factory.py
+++ b/abelfunctions/tests/test_complex_path_factory.py
@@ -2,16 +2,12 @@ import unittest
 import six
 
 import numpy
-from numpy import pi, Infinity, exp, sqrt, complex
+from numpy import pi, sqrt
 from abelfunctions.complex_path import (
-    ComplexPathPrimitive,
-    ComplexPath,
     ComplexLine,
     ComplexArc,
-    ComplexRay,
 )
 from abelfunctions.complex_path_factory import ComplexPathFactory
-from abelfunctions.riemann_surface import RiemannSurface
 from sage.all import QQ, QQbar, I
 
 class TestConstruction(unittest.TestCase):

--- a/abelfunctions/tests/test_jacobian.py
+++ b/abelfunctions/tests/test_jacobian.py
@@ -70,9 +70,9 @@ class TestJacobian(AbelfunctionsTestCase):
         h1 = list(itertools.product((0,0.5),repeat=g))
         h2 = list(itertools.product((0,0.5),repeat=g))
         for hj in h1:
-            hj = numpy.array(hj, dtype=numpy.complex)
+            hj = numpy.array(hj, dtype=complex)
             for hk in h2:
-                hk = numpy.array(hk, dtype=numpy.complex)
+                hk = numpy.array(hk, dtype=complex)
                 z = hj + numpy.dot(Omega,hk)
                 error = numpy.linalg.norm(J(2*z))
                 self.assertLess(error, 1e-14)

--- a/abelfunctions/tests/test_riemann_surface_path.py
+++ b/abelfunctions/tests/test_riemann_surface_path.py
@@ -1,7 +1,7 @@
 import unittest
 
 import numpy
-from numpy import pi, Infinity, exp, sqrt, power, complex
+from numpy import pi, sqrt
 from sage.all import QQ, QQbar, e, I
 
 from abelfunctions.complex_path import (

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -82,8 +82,8 @@ def frobenius_transform(A,g):
     the transformation matrix alpha.
 
     """
-    if not isinstance(A,numpy.matrix):
-        K = numpy.matrix(A, dtype=int)
+    if not isinstance(A,numpy.ndarray):
+        K = numpy.array(A, dtype=int)
     else:
         K = numpy.copy(A)
     dim = K.shape[0]

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -83,14 +83,14 @@ def frobenius_transform(A,g):
 
     """
     if not isinstance(A,numpy.matrix):
-        K = numpy.matrix(A, dtype=numpy.int)
+        K = numpy.matrix(A, dtype=int)
     else:
         K = numpy.copy(A)
     dim = K.shape[0]
 
     # the rand of an antisymmetric matrix is always even and is equal
     # to 2g in this case
-    T = numpy.eye(dim, dtype=numpy.int)
+    T = numpy.eye(dim, dtype=int)
 
     # create the block below the diagonal. make zeros everywhere else
     # in the first g columns
@@ -403,7 +403,7 @@ def intersection_matrix(final_edges, g):
     # the intersection matrix is anti-symmetric, so we only determine the
     # intersection numbers of the upper triangle
     num_final_edges = len(final_edges)
-    K = numpy.zeros((num_final_edges, num_final_edges), dtype=numpy.int)
+    K = numpy.zeros((num_final_edges, num_final_edges), dtype=int)
     for i in range(num_final_edges):
         ei = final_edges[i]
         for j in range(i+1,num_final_edges):

--- a/examples/test_alpha.py
+++ b/examples/test_alpha.py
@@ -142,7 +142,7 @@ if __name__=='__main__':
 
     # select a root at the base_point
     a = G.nodes[0]['basepoint']
-    fibre = map(numpy.complex,sympy.nroots(f.subs(x,a),n=15))
+    fibre = map(complex,sympy.nroots(f.subs(x,a),n=15))
 
     # analytically continue
     ypath = []
@@ -173,7 +173,7 @@ if __name__=='__main__':
     # plot
     fig = plt.figure()
     for j in range(n):
-        ypath = numpy.array(ys[j], dtype=numpy.complex)
+        ypath = numpy.array(ys[j], dtype=complex)
 
         ax = fig.add_subplot(1,n,j+1)
         ax.plot(ypath.real, ypath.imag, 'g')


### PR DESCRIPTION
- Replace `numpy.complex` -> `complex`, `numpy.int` -> `int` and `numpy.matrix` -> `numpy.array`
- Rewrite test_radius using pytest to simplify the test cases and catch the expected warning raised by `radius1` and `radius2`