### PR TITLE
Remove numpy.complex imports

### DIFF
--- a/abelfunctions/complex_path_factory.py
+++ b/abelfunctions/complex_path_factory.py
@@ -7,7 +7,7 @@ of a complex plane algebraic curve.
 """
 import numpy
 
-from numpy import double, complex, floor, angle
+from numpy import double, floor, angle
 from sage.all import infinity, QQbar, scatter_plot
 
 from abelfunctions.complex_path import (

--- a/abelfunctions/riemann_surface_path_factory.py
+++ b/abelfunctions/riemann_surface_path_factory.py
@@ -37,10 +37,9 @@ from abelfunctions.riemann_surface_path import (
     )
 from abelfunctions.utilities import matching_permutation
 from abelfunctions.complex_path_factory import ComplexPathFactory
-#from abelfunctions.skeleton import Skeleton
 from abelfunctions.ypath_factory import YPathFactory as Skeleton
 
-from numpy import complex, array
+from numpy import array
 from sage.all import infinity, CC, CDF, cached_method
 
 class RiemannSurfacePathFactory(object):


### PR DESCRIPTION
Addresses warnings
```
DeprecationWarning: `np.complex` is a deprecated alias for the builtin `complex`. To silence this warning, use `complex` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.complex128` here.
Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
  from numpy import double, complex, floor, angle
```