### PR TITLE
Use mamba to install sage for all versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         sage-version:
+          - '9.2'
           - '9.3'
           - '9.4'
           - '9.5'
@@ -47,6 +48,7 @@ jobs:
       - name: Install sage
         run: |
           conda config --add channels conda-forge
+          conda install mamba -y
           mamba install sage=${{ matrix.sage-version }} -y
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,34 +5,6 @@ name: Test
 on: [push]
 
 jobs:
-  test-old:
-    env:
-      SAGE: /home/runner/SageMath/sage
-    runs-on: ubuntu-18.04
-    strategy:
-      fail-fast: false
-      matrix:
-       include:
-         - SAGE_TARBALL: sage-9.2-Ubuntu_18.04-x86_64.tar.bz2
-           SAGE_SERVER: http://mirrors.mit.edu/sage/linux/64bit
-    steps:
-      - name: Install apt packages
-        run: |
-          sudo apt-get update
-          sudo apt-get install aria2 pbzip2
-      - name: Download SageMath
-        run: cd ${HOME} && aria2c ${{ matrix.SAGE_SERVER }}/${{ matrix.SAGE_TARBALL }}
-      - name: Extract SageMath
-        run: cd ${HOME} && pbzip2 -dc ${HOME}/${{ matrix.SAGE_TARBALL }} | tar xf -
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Install Python test dependencies
-        run: ${SAGE} -pip install -r test-requirements.txt
-      - name: Install Abelfunctions
-        run: ${SAGE} setup.py build_ext --inplace
-      - name: Run tests
-        run: ${SAGE} runtests.py -v
-
   test:
     runs-on: ubuntu-20.04
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Install sage
         run: |
           conda config --add channels conda-forge
-          conda install sage=${{ matrix.sage-version }} -y
+          mamba install sage=${{ matrix.sage-version }} -y
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Python test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,11 +45,12 @@ jobs:
           - '9.5'
           - '9.6'
     steps:
-      - name: Install sage
+      - name: Install mamba
         run: |
           conda config --add channels conda-forge
           conda install mamba -y
-          mamba install sage=${{ matrix.sage-version }} -y
+      - name: Install sage
+        run: mamba install sage=${{ matrix.sage-version }} -y
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Python test dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,12 +45,11 @@ jobs:
           - '9.5'
           - '9.6'
     steps:
-      - name: Install mamba
+      - name: Install sage
         run: |
           conda config --add channels conda-forge
           conda install mamba -y
-      - name: Install sage
-        run: mamba install sage=${{ matrix.sage-version }} -y
+          $CONDA/bin/mamba install sage=${{ matrix.sage-version }} -y
       - name: Checkout
         uses: actions/checkout@v2
       - name: Install Python test dependencies


### PR DESCRIPTION
@isuruf suggeted using `mamba` to install `sage`, which it turns out makes a huge difference to the install times (5m instead of 13m for 9.3+ and hours for 9.2). This means we can now install sage 9.2 via mamba instead of downloading binaries too.