### PR TITLE
Drop python 2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Gitter](https://badges.gitter.im/abelfunctions/abelfunctions.svg)](https://gitter.im/abelfunctions/abelfunctions?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge) [![Build Status](https://travis-ci.org/abelfunctions/abelfunctions.svg?branch=master)](https://travis-ci.org/abelfunctions/abelfunctions)
 
-A [Sage](http://www.sagemath.org) library for computing with Abelian functions, Riemann surfaces, and algebraic curves. Abelfunctions is the Ph.D. thesis work of [Chris Swierczewski](http://www.cswiercz.info). (GitHub: [cswiercz](https://github.com/cswiercz)).  Abelfunctions requires Sage 8.0 or later.
+A [Sage](http://www.sagemath.org) library for computing with Abelian functions, Riemann surfaces, and algebraic curves. Abelfunctions is the Ph.D. thesis work of [Chris Swierczewski](http://www.cswiercz.info). (GitHub: [cswiercz](https://github.com/cswiercz)).  Abelfunctions requires Sage 9.2 or later.
 
 ```python
 sage: from abelfunctions import *

--- a/abelfunctions/riemann_theta/riemann_theta.pyx
+++ b/abelfunctions/riemann_theta/riemann_theta.pyx
@@ -120,7 +120,7 @@ def oscillatory_part(z, Omega, epsilon, derivs, accuracy_radius, axis):
     # get the derivatives
     if len(derivs):
         derivs = numpy.array(derivs, dtype=complex).flatten()
-        nderivs = len(derivs) / g
+        nderivs = int(len(derivs) / g)
         derivs_real = numpy.ascontiguousarray(derivs.real, dtype=numpy.double)
         derivs_imag = numpy.ascontiguousarray(derivs.imag, dtype=numpy.double)
 

--- a/abelfunctions/tests/test_complex_path_factory.py
+++ b/abelfunctions/tests/test_complex_path_factory.py
@@ -1,5 +1,4 @@
 import unittest
-import six
 
 import numpy
 from numpy import pi, sqrt
@@ -29,18 +28,17 @@ class TestConstruction(unittest.TestCase):
         f = self.f1
         CPF = ComplexPathFactory(f, -1)
         discriminant_points = CPF.discriminant_points
-        six.assertCountEqual(self, discriminant_points, [QQbar(0)])
+        self.assertCountEqual(discriminant_points, [QQbar(0)])
 
         f = self.f2
         CPF = ComplexPathFactory(f, -2)
         discriminant_points = CPF.discriminant_points
-        six.assertCountEqual(self, discriminant_points, [QQbar(z) for z in [-I, I]])
+        self.assertCountEqual(discriminant_points, [QQbar(z) for z in [-I, I]])
 
         f = self.f3
         CPF = ComplexPathFactory(f, -2)
         discriminant_points = CPF.discriminant_points
-        six.assertCountEqual(self, discriminant_points,
-                              [QQbar(z) for z in [-I, -1, 1, I]])
+        self.assertCountEqual(discriminant_points, [QQbar(z) for z in [-I, -1, 1, I]])
 
     def test_base_point(self):
         f = self.f1

--- a/abelfunctions/tests/test_puiseux.py
+++ b/abelfunctions/tests/test_puiseux.py
@@ -1,5 +1,4 @@
 import unittest
-import six
 
 from abelfunctions.puiseux import (
     almost_monicize,
@@ -334,7 +333,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f1.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x**2, x**4*(x*(y + 1) + 1))])
 
@@ -343,7 +342,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f2.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x, x**2*y),
              (-x**2/2, -x**3*(y + 1)/2)])
@@ -353,7 +352,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f2.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(1/x**3, (x**2*y + x**2)/x**9)])
 
@@ -366,7 +365,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f4.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x, x*(y + 1)),
              (x, x*(y - 1))])
@@ -376,7 +375,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f4.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(1/(-x**2), (x*y + x)/x**4)])
 
@@ -389,7 +388,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f7.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x, y + r0),
              (x, y + r1),
@@ -400,7 +399,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f22.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x**3, x**5*(y + 1))])
 
@@ -409,7 +408,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f2.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(1/x**3, (x*y + x)/x**6)])
 
@@ -418,7 +417,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f23.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x, x*(x*y + 2) + 1),
              (x, x*(x*(y + 1) + 2) + 1)])
@@ -428,7 +427,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f23.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(1/x,y/x**7), (1/x,(1+y)/x**7)])
 
@@ -441,7 +440,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         x,y = self.f27.parent().gens()
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(x, x*(y + sqrt2)),
              (x, x*(y - sqrt2)),
@@ -455,7 +454,7 @@ class TestPuiseux(AbelfunctionsTestCase):
         series = self.get_PQ(f,a=infinity)
         x = QQbar['x,y'](x)
         y = QQbar['x,y'](y)
-        six.assertCountEqual(self, 
+        self.assertCountEqual( 
             series,
             [(1/x, (y+1)/x**3),
              (1/x, (y-1)/x**3)])

--- a/abelfunctions/tests/test_riemann_surface_path_factory.py
+++ b/abelfunctions/tests/test_riemann_surface_path_factory.py
@@ -1,5 +1,4 @@
 import unittest
-import six
 
 from abelfunctions.tests.test_abelfunctions import AbelfunctionsTestCase
 
@@ -291,19 +290,19 @@ class TestMonodromyPath(unittest.TestCase):
 
         PF = RiemannSurfacePathFactory(self.X1)
         branch_points, permutations = PF.monodromy_group()
-        six.assertCountEqual(self, branch_points, [QQbar(0), oo])
+        self.assertCountEqual( branch_points, [QQbar(0), oo])
         self.assertEqual(permutations[0], Permutation([1,0]))
 
         PF = RiemannSurfacePathFactory(self.X2)
         branch_points, permutations = PF.monodromy_group()
-        six.assertCountEqual(self, branch_points,
+        self.assertCountEqual( branch_points,
                               [QQbar(z) for z in [-I, I]])
         self.assertEqual(permutations[0], Permutation([1,0]))
         self.assertEqual(permutations[1], Permutation([1,0]))
 
         PF = RiemannSurfacePathFactory(self.X3)
         branch_points, permutations = PF.monodromy_group()
-        six.assertCountEqual(self, branch_points,
+        self.assertCountEqual( branch_points,
                               [QQbar(z) for z in [-I, -1, 1, I]])
         self.assertEqual(permutations[0], Permutation([1,0]))
         self.assertEqual(permutations[1], Permutation([1,0]))
@@ -312,7 +311,7 @@ class TestMonodromyPath(unittest.TestCase):
 
         PF = RiemannSurfacePathFactory(self.X4)
         branch_points, permutations = PF.monodromy_group()
-        six.assertCountEqual(self, branch_points,
+        self.assertCountEqual( branch_points,
                               [QQbar(z) for z in [-I, I]] + [oo])
         self.assertEqual(permutations[0], Permutation([2,0,1]))
         self.assertEqual(permutations[1], Permutation([2,0,1]))

--- a/setup.py
+++ b/setup.py
@@ -176,5 +176,12 @@ setup(
     ext_modules = cythonize(ext_modules),
     python_requires=">=3.6",
     platforms = ['all'],
-    cmdclass = {'clean':clean}
+    cmdclass = {'clean':clean},
+    classifiers=[
+        "Development Status :: 4 - Beta",
+        "Intended Audience :: Science/Research",
+        "Topic :: Scientific/Engineering :: Mathematics",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3 :: Only",
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -174,6 +174,7 @@ setup(
     packages = packages,
     install_requires=['six'],
     ext_modules = cythonize(ext_modules),
+    python_requires=">=3.8",
     platforms = ['all'],
     cmdclass = {'clean':clean}
 )

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ Python .pyc and Cython .o/.so output and run:
     $ sage setup.py clean
 """
 import os
-import sys
 import shutil
-import unittest
 from distutils.core import setup, Command
 from distutils.extension import Extension
 from Cython.Build import cythonize
@@ -172,7 +170,6 @@ setup(
     url = 'https://github.com/cswiercz/abelfunctions',
     license = 'MIT',
     packages = packages,
-    install_requires=['six'],
     python_requires=">=3.6",
     ext_modules = cythonize(ext_modules, compiler_directives={"language_level": "3"}),
     platforms = ['all'],

--- a/setup.py
+++ b/setup.py
@@ -173,8 +173,8 @@ setup(
     license = 'MIT',
     packages = packages,
     install_requires=['six'],
-    ext_modules = cythonize(ext_modules),
     python_requires=">=3.6",
+    ext_modules = cythonize(ext_modules, compiler_directives={"language_level": "3"}),
     platforms = ['all'],
     cmdclass = {'clean':clean},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -174,7 +174,7 @@ setup(
     packages = packages,
     install_requires=['six'],
     ext_modules = cythonize(ext_modules),
-    python_requires=">=3.8",
+    python_requires=">=3.6",
     platforms = ['all'],
     cmdclass = {'clean':clean}
 )


### PR DESCRIPTION
Closes #205

- Bump required sagemath version to 9.2 since that's the first version to drop support for python 2 and the [Sage installation guide](https://doc.sagemath.org/pdf/en/installation/installation.pdf) says "do not install a version of Sage older than 9.2".
- Require python 3 in setup.py
- Adds [classifiers](https://pypi.org/classifiers/) to further document the requiremnt for python 3
- Remove the dependency on `six` 
- Tells cython to compile `.pyx` files using python 3 (and fix resulting int cast error)