### PR TITLE
Remove python2 dependencies from test-requirements.txt

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,10 +1,4 @@
 # This file defines the Python dependencies which will be installed before 
 # testing Abelfunctions
-
-pytest==6.2.4 ; python_version > '2.7'
-pytest-xdist==2.2.1 ; python_version > '2.7'
-
-# SageMath < 9 uses python 2.7 which is not compatible with the latest version 
-# of many libraries so pin to older versions in this case 
-pytest==4.6.11 ; python_version <= '2.7'
-pytest-xdist==1.34.0 ; python_version <= '2.7'
+pytest==6.2.4
+pytest-xdist==2.2.1


### PR DESCRIPTION
Don't need these any more now that we're only supporting and testing against python3