### PR TITLE
Fix _node error

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Install Abelfunctions
         run: $CONDA/bin/mamba run -n sage sage setup.py build_ext --inplace
       - name: Run tests
-        run: $CONDA/bin/mamba run -n sage sage runtests.py -v
+        run: $CONDA/bin/mamba run -n sage sage runtests.py
 

--- a/abelfunctions/skeleton.py
+++ b/abelfunctions/skeleton.py
@@ -707,7 +707,7 @@ class Skeleton(object):
         """Converts `value` to its associated node on the y-skeleton `self.C`.
 
         """
-        nodes = [n for n,d in self.C.nodes(data=True)
+        nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]
         return nodes[0]
 

--- a/abelfunctions/skeleton.py
+++ b/abelfunctions/skeleton.py
@@ -707,6 +707,10 @@ class Skeleton(object):
         """Converts `value` to its associated node on the y-skeleton `self.C`.
 
         """
+        for n,d in self.C.nodes(data=True):
+            print('d', d)
+            print('value', value)
+            print('np.all', numpy.all(d['value'] == value))
         nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]
         return nodes[0]

--- a/abelfunctions/skeleton.py
+++ b/abelfunctions/skeleton.py
@@ -709,11 +709,11 @@ class Skeleton(object):
         """
         for node, data in self.C.nodes(data=True):
             try:
-                numpy.array(data['value'])
+                data_value = numpy.array(data['value'])
             except ValueError:
                 # Inhomogeneous shape
                 continue
-            if numpy.all(data['value'] == value) and not data['final']:
+            if numpy.all(data_value == value) and not data['final']:
                 return node
             
         raise ValueError(f'Unable to find node associated with {value}')

--- a/abelfunctions/skeleton.py
+++ b/abelfunctions/skeleton.py
@@ -707,13 +707,16 @@ class Skeleton(object):
         """Converts `value` to its associated node on the y-skeleton `self.C`.
 
         """
-        for n,d in self.C.nodes(data=True):
-            print('d', d)
-            print('value', value)
-            print('np.all', numpy.all(d['value'] == value))
-        nodes: list = [n for n,d in self.C.nodes(data=True)
-                 if numpy.all(d['value'] == value) and not d['final']]
-        return nodes[0]
+        for node, data in self.C.nodes(data=True):
+            try:
+                numpy.array(data['value'])
+            except ValueError:
+                # Inhomogeneous shape
+                continue
+            if numpy.all(data['value'] == value) and not data['final']:
+                return node
+            
+        raise ValueError(f'Unable to find node associated with {value}')
 
     def _values(self, ypath, rotations=False):
         """Converts a ypath from value data to node data.

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -645,8 +645,6 @@ class YPathFactory(object):
 
         """
         for node, data in self.C.nodes(data=True):
-            print('d value', data['value'])
-            print('value', value)
             try:
                 numpy.array(data['value'])
             except ValueError:
@@ -654,10 +652,8 @@ class YPathFactory(object):
                 continue
             if numpy.all(data['value'] == value) and not data['final']:
                 return node
-
-        # nodes: list = [n for n,d in self.C.nodes(data=True)
-        #          if numpy.all(d['value'] == value) and not d['final']]
-        # return nodes[0]
+            
+        raise ValueError(f'Unable to find node associated with {value}')
 
     def _values(self, ypath, rotations=False):
         """Converts a ypath from value data to node data.

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -647,8 +647,6 @@ class YPathFactory(object):
         for node, data in self.C.nodes(data=True):
             print('d value', data['value'])
             print('value', value)
-            print('')
-            print('all', numpy.all(numpy.array(data['value']) == value))
             try:
                 numpy.array(data['value'])
             except ValueError:

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -647,7 +647,7 @@ class YPathFactory(object):
         for n,d in self.C.nodes(data=True):
             print('d value', d['value'])
             print('value', value)
-            print('all', np.all(numpy.array(d['value']) == value))
+            print('all', numpy.all(numpy.array(d['value']) == value))
 
         nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -644,7 +644,7 @@ class YPathFactory(object):
         """Converts `value` to its associated node on the y-skeleton `self.C`.
 
         """
-        nodes = [n for n,d in self.C.nodes(data=True)
+        nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]
         return nodes[0]
 

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -646,11 +646,11 @@ class YPathFactory(object):
         """
         for node, data in self.C.nodes(data=True):
             try:
-                numpy.array(data['value'])
+                data_value = numpy.array(data['value'])
             except ValueError:
                 # Inhomogeneous shape
                 continue
-            if numpy.all(data['value'] == value) and not data['final']:
+            if numpy.all(data_value == value) and not data['final']:
                 return node
             
         raise ValueError(f'Unable to find node associated with {value}')

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -647,7 +647,7 @@ class YPathFactory(object):
         for n,d in self.C.nodes(data=True):
             print('d value', d['value'])
             print('value', value)
-            print('np.all', numpy.all(d['value'] == value))
+            print('all', all(d['value'] == value))
 
         nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -644,6 +644,11 @@ class YPathFactory(object):
         """Converts `value` to its associated node on the y-skeleton `self.C`.
 
         """
+        for n,d in self.C.nodes(data=True):
+            print('d value', d['value'])
+            print('value', value)
+            print('np.all', numpy.all(d['value'] == value))
+
         nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]
         return nodes[0]

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -644,14 +644,22 @@ class YPathFactory(object):
         """Converts `value` to its associated node on the y-skeleton `self.C`.
 
         """
-        for n,d in self.C.nodes(data=True):
-            print('d value', d['value'])
+        for node, data in self.C.nodes(data=True):
+            print('d value', data['value'])
             print('value', value)
-            print('all', numpy.all(numpy.array(d['value']) == value))
+            print('')
+            print('all', numpy.all(numpy.array(data['value']) == value))
+            try:
+                numpy.array(data['value'])
+            except ValueError:
+                # Inhomogeneous shape
+                continue
+            if numpy.all(data['value'] == value) and not data['final']:
+                return node
 
-        nodes: list = [n for n,d in self.C.nodes(data=True)
-                 if numpy.all(d['value'] == value) and not d['final']]
-        return nodes[0]
+        # nodes: list = [n for n,d in self.C.nodes(data=True)
+        #          if numpy.all(d['value'] == value) and not d['final']]
+        # return nodes[0]
 
     def _values(self, ypath, rotations=False):
         """Converts a ypath from value data to node data.

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -647,7 +647,7 @@ class YPathFactory(object):
         for n,d in self.C.nodes(data=True):
             print('d value', d['value'])
             print('value', value)
-            print('all', all(d['value'] == value))
+            print('all', all(numpy.array(d['value']) == value))
 
         nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]

--- a/abelfunctions/ypath_factory.py
+++ b/abelfunctions/ypath_factory.py
@@ -647,7 +647,7 @@ class YPathFactory(object):
         for n,d in self.C.nodes(data=True):
             print('d value', d['value'])
             print('value', value)
-            print('all', all(numpy.array(d['value']) == value))
+            print('all', np.all(numpy.array(d['value']) == value))
 
         nodes: list = [n for n,d in self.C.nodes(data=True)
                  if numpy.all(d['value'] == value) and not d['final']]

--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -1,6 +1,6 @@
 # Installation
 
-Abelfunctions requires [Sage (SageMath)](http://www.sagemath.org) 8.0 or later.
+Abelfunctions requires [Sage (SageMath)](http://www.sagemath.org) 9.2 or later.
 Sage makes it relatively easy to build and run the code.
 
 > **Note:** Depending on your system one of the below installation methods

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ INCLUDES = sage_include_directories()
 INCLUDES_NUMPY = get_numpy_include_dirs()
 for mod in ext_modules:
     mod.include_dirs.extend(INCLUDES)
-    mod.include_dirs.extend(INCLUDES_NUMPY)
+    # mod.include_dirs.extend(INCLUDES_NUMPY)
     mod.extra_compile_args.append('-w')
     mod.extra_compile_args.append('-std=c99')
 

--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ INCLUDES = sage_include_directories()
 INCLUDES_NUMPY = get_numpy_include_dirs()
 for mod in ext_modules:
     mod.include_dirs.extend(INCLUDES)
-    # mod.include_dirs.extend(INCLUDES_NUMPY)
+    mod.include_dirs.extend(INCLUDES_NUMPY)
     mod.extra_compile_args.append('-w')
     mod.extra_compile_args.append('-std=c99')
 


### PR DESCRIPTION
Tests [stopped working](https://github.com/abelfunctions/abelfunctions/actions/runs/5840187038/job/15839150721) at some point, I suspect networkx or numpy. In any case, this resolves the error for sage 9.2-9.7. Sage 9.8 is still broken but that seems to have a different problem. The error this PR solves is:

```
abelfunctions/riemann_constant_vector.py:398: in RiemannConstantVector
    K0 = compute_K0(X, epsilon1, epsilon2, C)
sage/misc/cachefunc.pyx:1001: in sage.misc.cachefunc.CachedFunction.__call__ (build/cythonized/sage/misc/cachefunc.c:6073)
    w = self.f(*args, **kwds)
abelfunctions/riemann_constant_vector.py:345: in compute_K0
    h = half_lattice_vector(X, C, epsilon1, epsilon2)
abelfunctions/riemann_constant_vector.py:252: in half_lattice_vector
    h = half_lattice_filter(h, J, C, D, epsilon=epsilon1)
abelfunctions/riemann_constant_vector.py:144: in half_lattice_filter
    Z = AbelMap(D) - 0.5*AbelMap(C)
abelfunctions/abelmap.py:285: in __call__
    return self.eval(*args)
abelfunctions/abelmap.py:348: in eval
    Pvalue = self._eval_primitive(P)
sage/misc/cachefunc.pyx:1948: in sage.misc.cachefunc.CachedMethodCaller.__call__ (build/cythonized/sage/misc/cachefunc.c:10410)
    w = self._instance_call(*args, **kwds)
sage/misc/cachefunc.pyx:1824: in sage.misc.cachefunc.CachedMethodCaller._instance_call (build/cythonized/sage/misc/cachefunc.c:9889)
    return self.f(self._instance, *args, **kwds)
abelfunctions/abelmap.py:387: in _eval_primitive
    gamma = X.path(P)
abelfunctions/riemann_surface.py:345: in path
    gamma = self.path_factory.path_to_place(P)
abelfunctions/riemann_surface_path_factory.py:222: in path_to_place
    return self._path_to_discriminant_place(P)
abelfunctions/riemann_surface_path_factory.py:310: in _path_to_discriminant_place
    gamma1 = self._path_to_regular_place(P1)
abelfunctions/riemann_surface_path_factory.py:359: in _path_to_regular_place
    ypath = self.skeleton.ypath_from_base_to_sheet(sheet_index)
abelfunctions/ypath_factory.py:[717](https://github.com/abelfunctions/abelfunctions/actions/runs/5840187038/job/15839150721#step:6:718): in ypath_from_base_to_sheet
    sheet = self._node(sheet)
abelfunctions/ypath_factory.py:647: in _node
    nodes = [n for n,d in self.C.nodes(data=True)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

.0 = <dict_itemiterator object at 0x7faea7fd55e0>

    nodes = [n for n,d in self.C.nodes(data=True)
>            if numpy.all(d['value'] == value) and not d['final']]
E   ValueError: setting an array element with a sequence. The requested array has an inhomogeneous shape after 1 dimensions. The detected shape was (2,) + inhomogeneous part.
```
