### PR TITLE
Fix warnings

### DIFF
--- a/abelfunctions/riemann_surface_path.pyx
+++ b/abelfunctions/riemann_surface_path.pyx
@@ -404,7 +404,7 @@ cdef class RiemannSurfacePathPrimitive:
            The integral of omega along self.
         """
         omega_gamma = self.parameterize(omega)
-        integral = scipy.integrate.romberg(omega_gamma, 0.0, 1.0)
+        integral = scipy.integrate.quad(omega_gamma, 0.0, 1.0)
         return integral
 
     def evaluate(self, omega, s):

--- a/abelfunctions/riemann_surface_path.pyx
+++ b/abelfunctions/riemann_surface_path.pyx
@@ -404,7 +404,7 @@ cdef class RiemannSurfacePathPrimitive:
            The integral of omega along self.
         """
         omega_gamma = self.parameterize(omega)
-        integral = scipy.integrate.quad(omega_gamma, 0.0, 1.0, complex_func=True)
+        integral = scipy.integrate.quad(omega_gamma, 0.0, 1.0, complex_func=True)[0]
         return integral
 
     def evaluate(self, omega, s):

--- a/abelfunctions/riemann_surface_path.pyx
+++ b/abelfunctions/riemann_surface_path.pyx
@@ -404,7 +404,7 @@ cdef class RiemannSurfacePathPrimitive:
            The integral of omega along self.
         """
         omega_gamma = self.parameterize(omega)
-        integral = scipy.integrate.quad(omega_gamma, 0.0, 1.0)
+        integral = scipy.integrate.quad(omega_gamma, 0.0, 1.0, complex_func=True)
         return integral
 
     def evaluate(self, omega, s):

--- a/abelfunctions/riemann_theta/integer_points.pyx
+++ b/abelfunctions/riemann_theta/integer_points.pyx
@@ -366,7 +366,7 @@ def integer_points_python(g, R, T):
         form. That is, each row of the output array is an integer vector over which
         the finite sum is computed.
     """
-    c = numpy.zeros((g,1))
+    c = numpy.zeros(g)
     points = _find_int_points_python(g-1, R, T, c, [])
     points = numpy.array(points, dtype=numpy.double)
     N = len(points)//g

--- a/abelfunctions/riemann_theta/tests/test_theta.py
+++ b/abelfunctions/riemann_theta/tests/test_theta.py
@@ -23,16 +23,7 @@ from numpy.random import randn
 from numpy.linalg import cholesky
 from abelfunctions.riemann_theta.radius import radius
 from abelfunctions.riemann_theta.riemann_theta import RiemannTheta
-
-# try to import mpmath's jtheta function
-NO_JTHETA = False
-try:
-    from sympy.mpmath import jtheta
-except ImportError:
-    try:
-        from mpmath import jtheta
-    except ImportError:
-        NO_JTHETA = True
+from mpmath import jtheta
 
 
 def thetag1(z, tau, N=2048):
@@ -568,7 +559,6 @@ class TestRiemannThetaValues(unittest.TestCase):
         rel_error_avg = numpy.mean(rel_error)
         self.assertLess(rel_error_avg, 5e-14)
 
-    @unittest.skipIf(NO_JTHETA, "Could not find sympy.mpmath.jtheta")
     def test_against_sympy_jtheta(self):
         N = 64
         sigma = 2

--- a/abelfunctions/tests/test_riemann_constant_vector.py
+++ b/abelfunctions/tests/test_riemann_constant_vector.py
@@ -27,7 +27,7 @@ class TestRCVTheta(AbelfunctionsTestCase):
     """
 
     # helper function for Riemann theta function theorem test
-    def is_theta_zero(self, X, W, prec=1e-7):
+    def is_theta_zero(self, X, W, prec=1e-6):
         Omega = X.riemann_matrix()
         J = Jacobian(X)
         W = J(W)
@@ -45,11 +45,11 @@ class TestRCVTheta(AbelfunctionsTestCase):
 
         D = sum(self.X11(2))
         W_D = AbelMap(D) + RiemannConstantVector(P0)
-        self.is_theta_zero(self.X11, W_D, prec=1e-6)
+        self.is_theta_zero(self.X11, W_D)
 
         # until AbelMap(P_oo,D) is implemented properly
         W_D_oo = AbelMap(P0, D) - D.degree * AbelMap(P_oo) + RiemannConstantVector(P_oo)
-        self.is_theta_zero(self.X11, W_D_oo, prec=1e-6)
+        self.is_theta_zero(self.X11, W_D_oo)
 
 
 class TestRCVCanonical(AbelfunctionsTestCase):

--- a/runtests.py
+++ b/runtests.py
@@ -64,7 +64,7 @@ def runtests(argv):
 
     # determine list of search patterns for tests
     patterns = " ".join(args)
-    pytest_args = ["-k", patterns, "--ignore=examples"]
+    pytest_args = ["-W error", "-k", patterns, "--ignore=examples"]
     if processes > 1:
         pytest_args += ["-n", str(processes)]
 


### PR DESCRIPTION
- Resolves #228
- Replaces deprecated `scipy.integrate.romberg` with `scipy.integrate.quad`
- Configure tests to error on warning