### PR TITLE
Add minimal scipy version to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -181,7 +181,11 @@ setup(
     url="https://github.com/cswiercz/abelfunctions",
     license="MIT",
     packages=packages,
-    python_requires=">=3.6",
+    python_requires=">=3.8",
+    install_requires=[
+        "numpy",
+        "scipy>=1.10.0"
+    ],
     ext_modules=ext_modules,
     platforms=["all"],
     cmdclass={"clean": clean},

--- a/setup.py
+++ b/setup.py
@@ -182,10 +182,7 @@ setup(
     license="MIT",
     packages=packages,
     python_requires=">=3.8",
-    install_requires=[
-        "numpy",
-        "scipy>=1.10.0"
-    ],
+    install_requires=["numpy", "scipy>=1.10.0"],
     ext_modules=ext_modules,
     platforms=["all"],
     cmdclass={"clean": clean},


### PR DESCRIPTION
1.10 is required for the complex_func argument to quad

Resolves #250