### PR TITLE
Remove deprecated ignore-init-module-imports

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,5 @@
 exclude = ["presentation.py", "examples/*"]
 
 [tool.ruff.lint]
-ignore-init-module-imports = true
 ignore = ["E741"]
 


### PR DESCRIPTION
Fixes
```
warning: The `ignore-init-module-imports` option is deprecated and will be removed in a future release. Ruff's handling of imports in `__init__.py` files has been improved (in preview) and unused imports will always be flagged.
```
in CI