### PR TITLE
doc/Installation.md: Remove outdated instructions using .spkg files

### DIFF
--- a/doc/Installation.md
+++ b/doc/Installation.md
@@ -25,30 +25,3 @@ sage --pip install --no-build-isolation git+https://github.com/abelfunctions/abe
    ```
    sage setup.py install
    ```
-
-# Alternate Method
-
-If the above does not work for whatever reason, try this instead:
-
-1. Download Abelfunctions using [Git](https://git-scm.com) or by clicking on
-   the *"Download Zip"* button on the right-hand side of the
-   [repository page](https://github.com/abelfunctions/abelfunctions).
-
-   a. In the latter case, make sure that the name of the directory containing
-   the package is exactly `abelfunctions`, not something like
-   `abelfunctions-master`; i.e., rename it if necessary.
-
-2. Convert the entire project into a Sage SPKG:
-
-   ```
-   tar cjf abelfunctions.spkg /path/to/abelfunctions
-   ```
-
-   *Note: some day this step will be done for you or will be unnecessary.*
-
-3. Install the SPKG into Sage:
-
-   ```
-   sage -p abelfunctions.spkg     # without running test suite
-   sage -p -c abelfunctions.spkg  # with running test suite
-   ```


### PR DESCRIPTION
`sage -p` with .spkg files has not been supported by Sage in many years.

We remove the section in the documentation that advertises this method.